### PR TITLE
Allow scrolling of the edit properties panel.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -107,7 +107,8 @@ a:hover {
     right: 0;
     top: 41px;
     bottom: 0;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     background: #000;
     z-index: 999;
 }


### PR DESCRIPTION
Currently, if multiple features are drawn you cannot scroll through them in the properties panel.
