### PR TITLE
dragexit is deprecated, listen for dragleave

### DIFF
--- a/src/import_panel.js
+++ b/src/import_panel.js
@@ -116,7 +116,7 @@ function importPanel(container, updates) {
                 readFile(f, 'drag');
             })
             .on('dragenter.localgpx', over)
-            .on('dragexit.localgpx', exit)
+            .on('dragleave.localgpx', exit)
             .on('dragover.localgpx', over);
 
         var import_landing = wrap.append('div')


### PR DESCRIPTION
Noticed that when I drag a file above the app, and decide not to drop it, the `dragover` CSS class on the body element is not removed.

The `dragexit` event seems to be deprecated and `dragleave` should be used...

Introduces flickering while dragging around the app, did not look how to fix that...
