### PR TITLE
Add argument to readFile call to avoid error

### DIFF
--- a/src/import_panel.js
+++ b/src/import_panel.js
@@ -172,7 +172,7 @@ function importPanel(container, updates) {
             .style('position', 'absolute')
             .style('height', '0')
             .on('change', function() {
-                if (this.files && this.files[0]) readFile(this.files[0], 'click');
+                if (this.files && this.files[0]) readFile(this.files[0], 'click', updates);
             });
     } else {
         wrap.append('p')


### PR DESCRIPTION
Fixes an error when importing a file.

When clicking import and selecting a file to open, there's a missing argument to readFile. I don't really know Javascript but it looks like this fixes it. Not sure if I should commit the site.js file with this.. when I ran `make` a bunch of `g070js` strings were replaced with `PWeb+5`, which I'm not sure about.
