### PR TITLE
zips and shps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "leaflet-hash": "https://github.com/mlevans/leaflet-hash/archive/master.tar.gz",
     "xtend": "~2.0.6",
     "clone": "~0.1.10",
-    "osm-and-geojson": "0.1.0"
+    "osm-and-geojson": "0.1.0",
+    "shpjs": "~1.5.2"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
Added zipped shapefile support, which also includes general zip support, aka drag and drop a zipfile with a geojson and kml in it.

If that's a bit to ambitious I also have [a version](https://github.com/calvinmetcalf/geojson.io/tree/shapefile) that only allows geojson and shapefiles inside the zipfile and will only return the first one, not parsing the other types avoids reorganizing readfile.
