### PR TITLE
Fix the numeric check on property values

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -21367,7 +21367,7 @@ module.exports = function(context) {
                 key = keys[i];
                 value = props[key];
                 feature.properties[key] = !isNaN(parseFloat(value)) &&
-                    /^(?!0.)/.test(value) ? Number(value) : value;
+                    isFinite(value) ? Number(value) : value;
             }
 
             return feature;

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -21334,7 +21334,7 @@ module.exports = function(context) {
                 key = keys[i];
                 value = props[key];
                 feature.properties[key] = !isNaN(parseFloat(value)) &&
-                    /^(?!0.)/.test(value) ? Number(value) : value;
+                    isFinite(value) ? Number(value) : value;
             }
 
             return feature;

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -71,7 +71,7 @@ module.exports = function(context) {
                 key = keys[i];
                 value = props[key];
                 feature.properties[key] = !isNaN(parseFloat(value)) &&
-                    /^(?!0.)/.test(value) ? Number(value) : value;
+                    isFinite(value) ? Number(value) : value;
             }
 
             return feature;


### PR DESCRIPTION
Fixes cases where '1 main street' would be parsed as a number and treated
as nan. The solution comes from
http://stackoverflow.com/questions/18082/validate-numbers-in-javascript-isnumeric/1830844#1830844

Fixes #299
