### PR TITLE
Fix coordinate order for distance calculation in popup

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -108,8 +108,8 @@ function bindPopup(l) {
     if (l.feature && l.feature.geometry) {
         if (l.feature.geometry.type === 'LineString') {
             var total = d3.pairs(l.feature.geometry.coordinates).reduce(function(total, pair) {
-                return total + L.latLng(pair[0][0], pair[0][1])
-                    .distanceTo(L.latLng(pair[1][0], pair[1][1]));
+                return total + L.latLng(pair[0][1], pair[0][0])
+                    .distanceTo(L.latLng(pair[1][1], pair[1][0]));
             }, 0);
             info += '<div>Length: ' + total.toFixed(2) + ' m</div>';
         } else if (l.feature.geometry.type === 'Point') {


### PR DESCRIPTION
Currently the distance/length of a line is wrong in the popup.

Example: The popup of a LineString from New York to San Francisco shows “5379378.45 m” while it’s about 4148 km in reality.

The order of the coordinates passed to L.latLng were in the wrong order (GeoJSON coordinates in the pair are [lon, lat, …], L.latLng expects [lat, lon])

This should also fix #310.
