### PR TITLE
refs mapbox/geojson.io#346 -- extract owner login

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -214,7 +214,7 @@ module.exports = function(context) {
                 });
                 break;
             case 'gist':
-                login = (d.user && d.user.login) || 'anonymous';
+                login = (d.owner && d.owner.login) || 'anonymous';
                 path = [login, d.id].join('/');
                 file = mapFile(d);
 


### PR DESCRIPTION
refs: mapbox/geojson.io#346

It looked like the `d.user` property was null. By inspecting the `d` variable, I've found that there was an `owner` property that was associated to the gist owner.

I have no mean to test this patch, but I hope it'd fix this.
