### PR TITLE
Request raw data for gists that are truncated

### DIFF
--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -1017,13 +1017,8 @@ function Buffer (subject, encoding, noZero) {
 
   var type = typeof subject
 
-  // Workaround: node's base64 implementation allows for non-padded strings
-  // while base64-js does not.
   if (encoding === 'base64' && type === 'string') {
-    subject = stringtrim(subject)
-    while (subject.length % 4 !== 0) {
-      subject = subject + '='
-    }
+    subject = base64clean(subject)
   }
 
   // Find the length
@@ -1978,6 +1973,18 @@ Buffer._augment = function (arr) {
   arr.toArrayBuffer = BP.toArrayBuffer
 
   return arr
+}
+
+var INVALID_BASE64_RE = /[^+\/0-9A-z]/g
+
+function base64clean (str) {
+  // Node strips out invalid characters like \n and \t from the string, base64-js does not
+  str = stringtrim(str).replace(INVALID_BASE64_RE, '')
+  // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+  while (str.length % 4 !== 0) {
+    str = str + '='
+  }
+  return str
 }
 
 function stringtrim (str) {
@@ -19573,20 +19580,14 @@ module.exports = function(context) {
         for (f in gist.files) {
             content = gist.files[f].content;
             if (f.indexOf('.geojson') !== -1 && content) {
-                return {
-                    name: f,
-                    content: JSON.parse(content)
-                };
+                return f;
             }
         }
 
         for (f in gist.files) {
             content = gist.files[f].content;
             if (f.indexOf('.json') !== -1 && content) {
-                return {
-                    name: f,
-                    file: JSON.parse(content)
-                };
+                return f;
             }
         }
     }
@@ -19649,8 +19650,25 @@ module.exports = function(context) {
             case 'gist':
                 var id = q.id.split(':')[1].split('/')[1];
 
+                // From: https://api.github.com/gists/dfa850f66f61ddc58bbf
+                // Gists > 1 MB will have truncated set to true. Request
+                // the raw URL in those cases.
                 source.gist.load(id, context, function(err, d) {
-                    return cb(err, d);
+                    if (err) return cb(err, d);
+
+                    var file = mapFile(d);
+                    // Test for .json or .geojson found
+                    if (typeof file === 'undefined') return cb(err, d);
+
+                    var f = d.files[file];
+                    if (f.truncated === true) {
+                        source.gist.loadRaw(f.raw_url, context, function(err, content) {
+                            if (err) return cb(err);
+                            return cb(err, xtend(d, { file: f.filename, content: JSON.parse(content) }));
+                        });
+                    } else {
+                        return cb(err, xtend(d, { file: f.filename, content: JSON.parse(f.content) }));
+                    }
                 });
 
                 break;
@@ -19764,15 +19782,14 @@ module.exports = function(context) {
             case 'gist':
                 login = (d.owner && d.owner.login) || 'anonymous';
                 path = [login, d.id].join('/');
-                file = mapFile(d);
 
-                if (file && file.content) data.set({ map: file.content });
+                if (d.content) data.set({ map: d.content });
                 data.set({
                     type: 'gist',
                     source: d,
                     meta: {
                         login: login,
-                        name: file && file.name
+                        name: d.file
                     },
                     path: path,
                     route: 'gist:' + path,
@@ -20633,6 +20650,7 @@ var fs = require('fs'),
 module.exports.save = save;
 module.exports.saveBlocks = saveBlocks;
 module.exports.load = load;
+module.exports.loadRaw = loadRaw;
 
 function saveBlocks(content, callback) {
     var endpoint = 'https://api.github.com/gists';
@@ -20722,6 +20740,16 @@ function load(id, context, callback) {
         .get();
 
     function onLoad(json) { callback(null, json); }
+    function onError(err) { callback(err, null); }
+}
+
+function loadRaw(url, context, callback) {
+    context.user.signXHR(d3.text(url))
+        .on('load', onLoad)
+        .on('error', onError)
+        .get();
+
+    function onLoad(file) { callback(null, file); }
     function onError(err) { callback(err, null); }
 }
 

--- a/src/source/gist.js
+++ b/src/source/gist.js
@@ -4,6 +4,7 @@ var fs = require('fs'),
 module.exports.save = save;
 module.exports.saveBlocks = saveBlocks;
 module.exports.load = load;
+module.exports.loadRaw = loadRaw;
 
 function saveBlocks(content, callback) {
     var endpoint = 'https://api.github.com/gists';
@@ -93,5 +94,15 @@ function load(id, context, callback) {
         .get();
 
     function onLoad(json) { callback(null, json); }
+    function onError(err) { callback(err, null); }
+}
+
+function loadRaw(url, context, callback) {
+    context.user.signXHR(d3.text(url))
+        .on('load', onLoad)
+        .on('error', onError)
+        .get();
+
+    function onLoad(file) { callback(null, file); }
     function onError(err) { callback(err, null); }
 }


### PR DESCRIPTION
Gist files greater than 1 MB are truncated in the gist API.
https://developer.github.com/changes/2014-05-06-gist-api-now-truncating-large-files/.
Look for the truncated flag and request the full contents from the
raw_url if it's set. 

Addresses #364.

A few days ago this fix didn't work - gist raw files are served from gist.githubusercontent.com, which was not CORS enabled. But after an email, @github support just set `Access-Control-Allow-Origin: *`. So this works now.
