### PR TITLE
prevent leaflet controls in upper right from falling on top of white bar

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -50,6 +50,8 @@ body.fullscreen .file-bar .fr {
     display:none;
 }
 
+body.fullscreen .leaflet-control-mapbox-geocoder { margin-top:50px; }
+
 .deemphasize { color: #888;}
 
 p.intro-hint {


### PR DESCRIPTION
Currently, the search button falls on top.

![screen shot 2014-08-28 at 6 39 59 pm](https://cloud.githubusercontent.com/assets/361323/4084659/31dbb49e-2f0d-11e4-9a0b-b8ef4e5164c3.png)
