### PR TITLE
Check if we have some feature properties before trying to manipulate them

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -66,6 +66,9 @@ module.exports = function(context) {
 
     data.mergeFeatures = function(features, src) {
         function coerceNum(feature) {
+            if(feature.properties === undefined) {
+                return feature;
+            }
             var props = feature.properties,
                 keys = Object.keys(props),
                 length = keys.length;


### PR DESCRIPTION
I was working with a file that had no feature properties and coerceNum fails.

This bubbles up the stack to a try/catch around the JSON parsing incorrectly informing me that my geojson is invalid.
