### PR TITLE
Fixes gist URL API

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -24202,7 +24202,7 @@ function save(context, callback) {
 }
 
 function load(id, context, callback) {
-    var endpoint = githubBase + '/gists';
+    var endpoint = githubBase + '/gists/';
     context.user.signXHR(d3.json(endpoint + id))
         .on('load', onLoad)
         .on('error', onError)

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -24122,7 +24122,7 @@ function save(context, callback) {
 }
 
 function load(id, context, callback) {
-    var endpoint = githubBase + '/gists';
+    var endpoint = githubBase + '/gists/';
     context.user.signXHR(d3.json(endpoint + id))
         .on('load', onLoad)
         .on('error', onError)

--- a/src/source/gist.js
+++ b/src/source/gist.js
@@ -91,7 +91,7 @@ function save(context, callback) {
 }
 
 function load(id, context, callback) {
-    var endpoint = githubBase + '/gists';
+    var endpoint = githubBase + '/gists/';
     context.user.signXHR(d3.json(endpoint + id))
         .on('load', onLoad)
         .on('error', onError)


### PR DESCRIPTION
Adds a missing '/' in the URL used to fetch a gist.

For example, here's the link in API.md which is currently broken:
http://geojson.io/#id=gist:tmcw/e9a29ad54dbaa83dee08&map=8/39.198/-76.981

Previously was trying to fetch URLs like: https://api.github.com/gistsabcde - which would 404.
Proper URL is like: https://api.github.com/gists/abcde