### PR TITLE
Change GitSpatial link to GitHub repo, not the no-longer-running app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fast, simple editor for map data. Read more on [Mapbox](http://www.mapbox.com/
 
 **Sites**
 
-* [GitSpatial](http://gitspatial.com/) makes GeoJSON on GitHub more like an API
+* [GitSpatial](https://github.com/JasonSanford/gitspatial) makes GeoJSON on GitHub more like an API
 
 ## API
 


### PR DESCRIPTION
I changed this link to point to the GitHub repo because I shut down the GitSpatial server a month or so ago. Feel free to just remove the link entirely if you want, since the app has been shut down :smile:.