### PR TITLE
Tabbed popups and style inputs

### DIFF
--- a/css/marker.css
+++ b/css/marker.css
@@ -1,6 +1,4 @@
 .marker-properties-limit {
-    overflow:auto;
-    max-height:150px;
     max-width:500px;
 }
 
@@ -30,4 +28,55 @@
 .marker-properties tr:nth-child(even) th,
 .marker-properties tr:nth-child(even) td {
     background-color:#f7f7f7;
+}
+
+/* Tabs
+------------------------------------------------------- */
+.clearfix{
+    width:100%;
+}
+
+.tabs-ui {
+    position:relative;
+    min-height:200px;
+    min-width:225px;
+    clear:both;
+}
+.tab {
+    float:left;
+}
+.tab label {
+    background:#eee;
+    padding:10px;
+    border:1px solid #ccc;
+    margin-left:-1px;
+    position:relative;
+    left:1px;
+    top:1px;
+    cursor:pointer;
+}
+.tab label:hover {
+    background:#f8f8f8;
+}
+.tab [type=radio] {
+    display:none;
+}
+.tab .content {
+    background:white;
+    position:absolute;
+    top:28px;
+    left:0;
+    right:0;
+    bottom:0;
+    padding:5px;
+    border:1px solid #ccc;
+    overflow:auto;
+}
+.tab [type=radio]:checked ~ label {
+    background:white;
+    border-bottom:1px solid white;
+    z-index:2;
+}
+.tab [type=radio]:checked ~ label ~ .content {
+    z-index:1;
 }

--- a/css/marker.css
+++ b/css/marker.css
@@ -1,18 +1,21 @@
-.marker-properties-limit {
-    max-width:500px;
-}
-
 .marker-properties {
     border-collapse:collapse;
     font-size:11px;
     border:1px solid #ccc;
     margin:0;
+    width:100%;
 }
 
-.marker-properties td,
+
 .marker-properties th {
+    width:40%;
+    min-width:100px;
     white-space:nowrap;
     border:1px solid #ccc;
+}
+
+.marker-properties td {
+    width:60%;
 }
 
 .marker-properties.display td,
@@ -31,7 +34,8 @@
 }
 
 .leaflet-popup-content {
-    margin-bottom: -25px;
+    margin-bottom:-25px;
+    width:100%;
 }
 
 /* Tabs
@@ -42,9 +46,15 @@
 
 .tabs-ui {
     position:relative;
-    min-height:200px;
-    min-width:225px;
+    height:250px;
+    width:300px;
     clear:both;
+}
+@media (max-width: 767px){
+    .tabs-ui {
+        height:250px;
+        width:250px;
+    }
 }
 .tab {
     float:left;

--- a/css/marker.css
+++ b/css/marker.css
@@ -30,6 +30,10 @@
     background-color:#f7f7f7;
 }
 
+.leaflet-popup-content {
+    margin-bottom: -25px;
+}
+
 /* Tabs
 ------------------------------------------------------- */
 .clearfix{

--- a/css/site.css
+++ b/css/site.css
@@ -224,7 +224,7 @@ button.major:hover {
 }
 
 .leaflet-popup-content-wrapper table input {
-    width:120px;
+    width:100%;
     background:transparent;
 }
 
@@ -521,7 +521,6 @@ div.children a {
 
 .metadata {
     width:100%;
-    margin:10px 0;
 }
 
 .metadata td {

--- a/css/site.css
+++ b/css/site.css
@@ -127,6 +127,10 @@ button.major {
     padding:5px;
 }
 
+button.major:hover {
+    background:#f8f8f8;
+}
+
 .top .collapse-button {
     position:absolute;
     top:0;

--- a/data/maki.json
+++ b/data/maki.json
@@ -1,0 +1,1233 @@
+[
+    {
+        "name": "Circle stroked",
+        "tags": [
+            "circle",
+            "disc",
+            "shape",
+            "shapes",
+            "geometric",
+            "stroke",
+            "round"
+        ],
+        "icon": "circle-stroked"
+    },
+    {
+        "name": "Circle solid",
+        "tags": [
+            "circle",
+            "shape",
+            "shapes",
+            "geometric",
+            "round"
+        ],
+        "icon": "circle"
+    },
+    {
+        "name": "Square stroked",
+        "tags": [
+            "box",
+            "square",
+            "shapes",
+            "shape",
+            "geometric",
+            "stroke"
+        ],
+        "icon": "square-stroked"
+    },
+    {
+        "name": "Square solid",
+        "tags": [
+            "box",
+            "square",
+            "shape",
+            "shapes",
+            "geometric"
+        ],
+        "icon": "square"
+    },
+    {
+        "name": "Triangle stroked",
+        "tags": [
+            "triangle",
+            "shape",
+            "shapes",
+            "geometric",
+            "stroke"
+        ],
+        "icon": "triangle-stroked"
+    },
+    {
+        "name": "Triangle solid",
+        "tags": [
+            "triangle",
+            "shape",
+            "shapes",
+            "geometric"
+        ],
+        "icon": "triangle"
+    },
+    {
+        "name": "Star stroked",
+        "tags": [
+            "star",
+            "shape",
+            "shapes",
+            "geometric",
+            "stroke"
+        ],
+        "icon": "star-stroked"
+    },
+    {
+        "name": "Star solid",
+        "tags": [
+            "star",
+            "shape",
+            "shapes",
+            "geometric"
+        ],
+        "icon": "star"
+    },
+    {
+        "name": "Cross",
+        "tags": [
+            "cross",
+            "x",
+            "ex",
+            "shape",
+            "shapes",
+            "geometric"
+        ],
+        "icon": "cross"
+    },
+    {
+        "name": "Marker Stroke",
+        "tags": [
+            "marker",
+            "point",
+            "shape",
+            "shapes",
+            "stroke"
+        ],
+        "icon": "marker-stroked"
+    },
+    {
+        "name": "Marker Solid",
+        "tags": [
+            "marker",
+            "point",
+            "shape",
+            "shapes"
+        ],
+        "icon": "marker"
+    },
+    {
+        "name": "Religious Jewish",
+        "tags": [
+            "jewish",
+            "judaism",
+            "hebrew",
+            "star",
+            "david",
+            "religious",
+            "religion",
+            "temple",
+            "synagogue"
+        ],
+        "icon": "religious-jewish"
+    },
+    {
+        "name": "Religious Christian",
+        "tags": [
+            "christian",
+            "cross",
+            "religious",
+            "religion",
+            "church",
+            "cathedral"
+        ],
+        "icon": "religious-christian"
+    },
+    {
+        "name": "Religious Muslim",
+        "tags": [
+            "muslim",
+            "crescent",
+            "star",
+            "religious",
+            "religion",
+            "mosque"
+        ],
+        "icon": "religious-muslim"
+    },
+    {
+        "name": "Cemetery",
+        "tags": [
+            "cemetery",
+            "graveyard",
+            "funeral",
+            "religious",
+            "religion",
+            "memorial"
+        ],
+        "icon": "cemetery"
+    },
+    {
+        "name": "Rocket",
+        "tags": [
+            "rocket",
+            "space",
+            "launch",
+            "transportation"
+        ],
+        "icon": "rocket"
+    },
+    {
+        "name": "Airport",
+        "tags": [
+            "airplane",
+            "plane",
+            "airport",
+            "transportation"
+        ],
+        "icon": "airport"
+    },
+    {
+        "name": "Heliport",
+        "tags": [
+            "heliport",
+            "helicopter",
+            "transportation"
+        ],
+        "icon": "heliport"
+    },
+    {
+        "name": "Rail",
+        "tags": [
+            "rail",
+            "train",
+            "transportation"
+        ],
+        "icon": "rail"
+    },
+    {
+        "name": "Rail Metro",
+        "tags": [
+            "rail",
+            "train",
+            "metro",
+            "subway",
+            "rapid-transit",
+            "transportation"
+        ],
+        "icon": "rail-metro"
+    },
+    {
+        "name": "Rail Light",
+        "tags": [
+            "rail",
+            "train",
+            "light-rail",
+            "transportation"
+        ],
+        "icon": "rail-light"
+    },
+    {
+        "name": "Bus",
+        "tags": [
+            "vehicle",
+            "bus",
+            "transportation"
+        ],
+        "icon": "bus"
+    },
+    {
+        "name": "Fuel",
+        "tags": [
+            "petrol",
+            "fuel",
+            "gas",
+            "transportation",
+            "station"
+        ],
+        "icon": "fuel"
+    },
+    {
+        "name": "Parking",
+        "tags": [
+            "parking",
+            "transportation"
+        ],
+        "icon": "parking"
+    },
+    {
+        "name": "Parking Garage",
+        "tags": [
+            "parking",
+            "transportation",
+            "garage"
+        ],
+        "icon": "parking-garage"
+    },
+    {
+        "name": "Airfield",
+        "tags": [
+            "airfield",
+            "airport",
+            "plane",
+            "landing strip"
+        ],
+        "icon": "airfield"
+    },
+    {
+        "name": "Roadblock",
+        "tags": [
+            "roadblock",
+            "stop",
+            "warning",
+            "dead end"
+        ],
+        "icon": "roadblock"
+    },
+    {
+        "name": "Ferry",
+        "tags": [
+            "ship",
+            "boat",
+            "water",
+            "ferry",
+            "transportation"
+        ],
+        "icon": "ferry"
+    },
+    {
+        "name": "Harbor",
+        "tags": [
+            "marine",
+            "dock",
+            "water",
+            "wharf"
+        ],
+        "icon": "harbor"
+    },
+    {
+        "name": "Bicycle",
+        "tags": [
+            "cycling",
+            "cycle",
+            "transportation"
+        ],
+        "icon": "bicycle"
+    },
+    {
+        "name": "Park",
+        "tags": [
+            "recreation",
+            "park",
+            "forest",
+            "tree",
+            "green",
+            "woods",
+            "nature"
+        ],
+        "icon": "park"
+    },
+    {
+        "name": "Park 2",
+        "tags": [
+            "recreation",
+            "park",
+            "forest",
+            "tree",
+            "green",
+            "woods",
+            "nature"
+        ],
+        "icon": "park2"
+    },
+    {
+        "name": "Museum",
+        "tags": [
+            "recreation",
+            "museum",
+            "tourism"
+        ],
+        "icon": "museum"
+    },
+    {
+        "name": "Lodging",
+        "tags": [
+            "lodging",
+            "hotel",
+            "recreation",
+            "motel",
+            "tourism"
+        ],
+        "icon": "lodging"
+    },
+    {
+        "name": "Monument",
+        "tags": [
+            "recreation",
+            "statue",
+            "monument",
+            "tourism"
+        ],
+        "icon": "monument"
+    },
+    {
+        "name": "Zoo",
+        "tags": [
+            "recreation",
+            "zoo",
+            "animal",
+            "giraffe"
+        ],
+        "icon": "zoo"
+    },
+    {
+        "name": "Garden",
+        "tags": [
+            "recreation",
+            "garden",
+            "park",
+            "flower",
+            "nature"
+        ],
+        "icon": "garden"
+    },
+    {
+        "name": "Campsite",
+        "tags": [
+            "recreation",
+            "campsite",
+            "camp",
+            "camping",
+            "tent",
+            "nature"
+        ],
+        "icon": "campsite"
+    },
+    {
+        "name": "Theatre",
+        "tags": [
+            "recreation",
+            "theatre",
+            "theater",
+            "entertainment",
+            "play",
+            "performance"
+        ],
+        "icon": "theatre"
+    },
+    {
+        "name": "Art gallery",
+        "tags": [
+            "art",
+            "center",
+            "museum",
+            "gallery",
+            "creative",
+            "recreation",
+            "entertainment",
+            "studio"
+        ],
+        "icon": "art-gallery"
+    },
+    {
+        "name": "Pitch",
+        "tags": [
+            "pitch",
+            "track",
+            "athletic",
+            "sports",
+            "field"
+        ],
+        "icon": "pitch"
+    },
+    {
+        "name": "Soccer",
+        "tags": [
+            "soccer",
+            "sports"
+        ],
+        "icon": "soccer"
+    },
+    {
+        "name": "American Football",
+        "tags": [
+            "football",
+            "sports"
+        ],
+        "icon": "america-football"
+    },
+    {
+        "name": "Tennis",
+        "tags": [
+            "tennis",
+            "court",
+            "ball",
+            "sports"
+        ],
+        "icon": "tennis"
+    },
+    {
+        "name": "Basketball",
+        "tags": [
+            "basketball",
+            "ball",
+            "sports"
+        ],
+        "icon": "basketball"
+    },
+    {
+        "name": "Baseball",
+        "tags": [
+            "baseball",
+            "softball",
+            "ball",
+            "sports"
+        ],
+        "icon": "baseball"
+    },
+    {
+        "name": "Golf",
+        "tags": [
+            "golf",
+            "sports",
+            "course"
+        ],
+        "icon": "golf"
+    },
+    {
+        "name": "Swimming",
+        "tags": [
+            "swimming",
+            "water",
+            "swim",
+            "sports"
+        ],
+        "icon": "swimming"
+    },
+    {
+        "name": "Cricket",
+        "tags": [
+            "cricket",
+            "sports"
+        ],
+        "icon": "cricket"
+    },
+    {
+        "name": "Skiing",
+        "tags": [
+            "winter",
+            "skiing",
+            "ski",
+            "sports"
+        ],
+        "icon": "skiing"
+    },
+    {
+        "name": "School",
+        "tags": [
+            "school",
+            "highschool",
+            "elementary",
+            "children",
+            "amenity",
+            "middle"
+        ],
+        "icon": "school"
+    },
+    {
+        "name": "College",
+        "tags": [
+            "college",
+            "school",
+            "amenity",
+            "university"
+        ],
+        "icon": "college"
+    },
+    {
+        "name": "Library",
+        "tags": [
+            "library",
+            "books",
+            "amenity"
+        ],
+        "icon": "library"
+    },
+    {
+        "name": "Post",
+        "tags": [
+            "post",
+            "office",
+            "amenity",
+            "mail",
+            "letter"
+        ],
+        "icon": "post"
+    },
+    {
+        "name": "Fire station",
+        "tags": [
+            "fire",
+            "station",
+            "amenity"
+        ],
+        "icon": "fire-station"
+    },
+    {
+        "name": "Town hall",
+        "tags": [
+            "townhall",
+            "mayor",
+            "building",
+            "amenity",
+            "government"
+        ],
+        "icon": "town-hall"
+    },
+    {
+        "name": "Police",
+        "tags": [
+            "police",
+            "jail",
+            "arrest",
+            "amenity",
+            "station"
+        ],
+        "icon": "police"
+    },
+    {
+        "name": "Prison",
+        "tags": [
+            "prison",
+            "jail",
+            "amenity"
+        ],
+        "icon": "prison"
+    },
+    {
+        "name": "Embassy",
+        "tags": [
+            "embassy",
+            "diplomacy",
+            "consulate",
+            "amenity",
+            "flag"
+        ],
+        "icon": "embassy"
+    },
+    {
+        "name": "Beer",
+        "tags": [
+            "bar",
+            "beer",
+            "drink",
+            "commercial",
+            "biergarten",
+            "pub"
+        ],
+        "icon": "beer"
+    },
+    {
+        "name": "Restaurant",
+        "tags": [
+            "restaurant",
+            "commercial"
+        ],
+        "icon": "restaurant"
+    },
+    {
+        "name": "Cafe",
+        "tags": [
+            "cafe",
+            "coffee",
+            "commercial",
+            "tea"
+        ],
+        "icon": "cafe"
+    },
+    {
+        "name": "Shop",
+        "tags": [
+            "shop",
+            "mall",
+            "commercial",
+            "store"
+        ],
+        "icon": "shop"
+    },
+    {
+        "name": "Fast Food",
+        "tags": [
+            "food",
+            "fast",
+            "commercial",
+            "burger",
+            "drive-through"
+        ],
+        "icon": "fast-food"
+    },
+    {
+        "name": "Bar",
+        "tags": [
+            "bar",
+            "drink",
+            "commercial",
+            "club",
+            "martini",
+            "lounge"
+        ],
+        "icon": "bar"
+    },
+    {
+        "name": "Bank",
+        "tags": [
+            "bank",
+            "atm",
+            "commercial",
+            "money"
+        ],
+        "icon": "bank"
+    },
+    {
+        "name": "Grocery",
+        "tags": [
+            "food",
+            "grocery",
+            "commercial",
+            "store",
+            "market"
+        ],
+        "icon": "grocery"
+    },
+    {
+        "name": "Cinema",
+        "tags": [
+            "cinema",
+            "theatre",
+            "film",
+            "movie",
+            "commercial",
+            "theater",
+            "entertainment"
+        ],
+        "icon": "cinema"
+    },
+    {
+        "name": "Pharmacy",
+        "tags": [
+            "pharmacy",
+            "drugs",
+            "medication",
+            "social",
+            "medicine",
+            "prescription"
+        ],
+        "icon": "pharmacy"
+    },
+    {
+        "name": "Hospital",
+        "tags": [
+            "hospital",
+            "health",
+            "medication",
+            "social",
+            "medicine",
+            "medical",
+            "clinic"
+        ],
+        "icon": "hospital"
+    },
+    {
+        "name": "Danger",
+        "tags": [
+            "minefield",
+            "landmine",
+            "disaster",
+            "dangerous",
+            "hazard"
+        ],
+        "icon": "danger"
+    },
+    {
+        "name": "Industrial",
+        "tags": [
+            "industrial",
+            "factory",
+            "property",
+            "building"
+        ],
+        "icon": "industrial"
+    },
+    {
+        "name": "Warehouse",
+        "tags": [
+            "warehouse",
+            "property",
+            "storage",
+            "building"
+        ],
+        "icon": "warehouse"
+    },
+    {
+        "name": "Commercial",
+        "tags": [
+            "commercial",
+            "property",
+            "business",
+            "building"
+        ],
+        "icon": "commercial"
+    },
+    {
+        "name": "Building",
+        "tags": [
+            "building",
+            "property",
+            "structure",
+            "business",
+            "building"
+        ],
+        "icon": "building"
+    },
+    {
+        "name": "Place of worship",
+        "tags": [
+            "religion",
+            "ceremony",
+            "religious",
+            "nondenominational",
+            "church",
+            "temple"
+        ],
+        "icon": "place-of-worship"
+    },
+    {
+        "name": "Alcohol shop",
+        "tags": [
+            "alcohol",
+            "liquor",
+            "store",
+            "shop",
+            "beer",
+            "wine",
+            "vodka"
+        ],
+        "icon": "alcohol-shop"
+    },
+    {
+        "name": "Logging",
+        "tags": [
+            "logger",
+            "chainsaw",
+            "woods",
+            "industry"
+        ],
+        "icon": "logging"
+    },
+    {
+        "name": "Oil well",
+        "tags": [
+            "oil",
+            "natural",
+            "environment",
+            "industry",
+            "resources"
+        ],
+        "icon": "oil-well"
+    },
+    {
+        "name": "Slaughterhouse",
+        "tags": [
+            "cows",
+            "cattle",
+            "food",
+            "meat",
+            "industry",
+            "resources"
+        ],
+        "icon": "slaughterhouse"
+    },
+    {
+        "name": "Dam",
+        "tags": [
+            "water",
+            "natural",
+            "hydro",
+            "hydroelectric",
+            "energy",
+            "environment",
+            "industry",
+            "resources"
+        ],
+        "icon": "dam"
+    },
+    {
+    "name": "Water",
+    "tags": [
+        "water",
+        "natural",
+        "hydro",
+        "lake",
+        "river",
+        "ocean",
+        "resources"
+    ],
+    "icon": "water"
+    },
+    {
+    "name": "Wetland",
+    "tags": [
+        "water",
+        "swamp",
+        "natural"
+    ],
+    "icon": "wetland"
+    },
+    {
+    "name": "Disability",
+    "tags": [
+        "handicap",
+        "wheelchair",
+        "access"
+    ],
+    "icon": "disability"
+    },
+    {
+    "name": "Telephone",
+    "tags": [
+        "payphone",
+        "call"
+    ],
+    "icon": "telephone"
+    },
+    {
+    "name": "Emergency Telephone",
+    "tags": [
+        "payphone",
+        "danger",
+        "safety",
+        "call"
+    ],
+    "icon": "emergency-telephone"
+    },
+    {
+    "name": "Toilets",
+    "tags": [
+        "bathroom",
+        "men",
+        "women",
+        "sink",
+        "washroom",
+        "lavatory"
+    ],
+    "icon": "toilets"
+    },
+    {
+    "name": "Waste Basket",
+    "tags": [
+        "trash",
+        "rubbish",
+        "bin",
+        "garbage"
+    ],
+    "icon": "waste-basket"
+    },
+    {
+    "name": "Music",
+    "tags": [
+        "stage",
+        "performance",
+        "band",
+        "concert",
+        "venue"
+    ],
+    "icon": "music"
+    },
+    {
+    "name": "Land Use",
+    "tags": [
+        "zoning",
+        "usage",
+        "area"
+    ],
+    "icon": "land-use"
+    },
+    {
+    "name": "City",
+    "tags": [
+        "area",
+        "point",
+        "place",
+        "urban"
+    ],
+    "icon": "city"
+    },
+    {
+    "name": "Town",
+    "tags": [
+        "area",
+        "point",
+        "place",
+        "small"
+    ],
+    "icon": "town"
+    },
+    {
+    "name": "Village",
+    "tags": [
+        "area",
+        "point",
+        "place",
+        "small",
+        "rural"
+    ],
+    "icon": "village"
+    },
+    {
+    "name": "Farm",
+    "tags": [
+        "building",
+        "farming",
+        "crops",
+        "plants",
+        "agriculture",
+        "rural"
+    ],
+    "icon": "farm"
+    },
+    {
+    "name": "Bakery",
+    "tags": [
+        "bakery",
+        "pastry",
+        "croissant",
+        "food",
+        "shop",
+        "bread"
+    ],
+    "icon": "bakery"
+    },
+	{
+    "name": "Dog Park",
+    "tags": [
+        "dog",
+        "pet"
+    ],
+    "icon": "dog-park"
+    },
+   {
+    "name": "Lighthouse",
+    "tags": [
+        "building",
+        "navigation",
+        "nautical",
+        "ocean",
+        "logistics"
+    ],
+    "icon": "lighthouse"
+    },
+    {
+    "name": "Clothing Store",
+    "tags": [
+        "clothing",
+        "store",
+        "shop"
+    ],
+    "icon": "clothing-store"
+    },
+    {
+    "name": "Polling Place",
+    "tags": [
+        "poll",
+        "polling",
+        "vote"
+    ],
+    "icon": "polling-place"
+    },
+    {
+    "name": "Playground",
+    "tags": [
+        "playground",
+        "play",
+        "park",
+        "children"
+    ],
+    "icon": "playground"
+    },
+    {
+    "name": "Entrance",
+    "tags": [
+        "entrance",
+        "enter",
+        "subway",
+        "rail"
+    ],
+    "icon": "entrance"
+    },
+    {
+    "name": "Heart",
+    "tags": [
+        "heart",
+        "love",
+        "shape",
+        "shapes",
+        "wedding"
+    ],
+    "icon": "heart"
+    },
+    {
+    "name": "London Underground",
+    "tags": [
+        "deprecated"
+    ],
+    "icon": "london-underground"
+    },
+    {
+    "name": "Minefield",
+    "tags": [
+        "deprecated"
+    ],
+    "icon": "minefield"
+    },
+    {
+    "name": "Rail Underground",
+    "tags": [
+        "deprecated"
+    ],
+    "icon": "rail-underground"
+    },
+    {
+    "name": "Rail Above",
+    "tags": [
+        "deprecated"
+    ],
+    "icon": "rail-above"
+    },
+    {
+     "name": "Camera",
+     "tags": [
+         "camera",
+         "photo",
+         "commercial",
+         "shop"
+     ],
+     "icon": "camera"
+    },
+    {
+    "name": "Laundry",
+    "tags": [
+        "laundry",
+        "washing machine",
+        "dry_cleaning",
+        "commercial",
+        "store"
+    ],
+    "icon": "laundry"
+    },
+    {
+        "name": "Car",
+        "tags": [
+            "car",
+            "auto",
+            "vehicle",
+            "transportation"
+        ],
+        "icon": "car"
+    },
+    {
+    "name": "Suitcase",
+    "tags": [
+      "suitcase",
+      "travel",
+      "travel agency",
+      "commercial",
+      "store"
+    ],
+    "icon": "suitcase"
+    },
+    {
+    "name": "Hairdresser",
+    "tags": [
+      "scissors",
+      "barber shop",
+      "barber",
+      "stylist",
+      "hair",
+      "cut",
+      "salon"
+    ],
+    "icon": "hairdresser"
+    },
+    {
+    "name": "Chemist",
+    "tags": [
+      "shop",
+      "science",
+      "chemistry",
+      "experiment",
+      "research",
+      "pharmacy"
+    ],
+    "icon": "chemist"
+    },
+    {
+    "name": "Mobile phone",
+    "tags": [
+      "phone",
+      "cellphone",
+      "communication",
+      "mobile"
+    ],
+    "icon": "mobilephone"
+    },
+    {
+    "name": "Scooter",
+    "tags": [
+      "bike",
+      "transportation",
+      "vehicle",
+      "route",
+      "moped",
+      "motorcycle"
+    ],
+    "icon": "scooter"
+    },
+    {
+    "name": "Gift",
+    "tags": [
+      "gift",
+      "shop",
+      "commercial",
+      "store"
+    ],
+    "icon": "gift"
+    },
+    {
+    "name": "Ice cream",
+    "tags": [
+      "ice",
+      "sweets",
+      "food",
+      "shop"
+    ],
+    "icon": "ice-cream"
+    },
+    {
+    "name": "Dentist",
+    "tags": [
+      "dentist",
+      "tooth",
+      "health",
+      "medication",
+      "social",
+      "medicine",
+      "medical"
+    ],
+    "icon": "dentist"
+    }
+]

--- a/dist/site.js
+++ b/dist/site.js
@@ -25323,7 +25323,16 @@ var popup = require('../lib/popup'),
     customHash = require('../lib/custom_hash.js'),
     qs = require('qs-hash'),
     LGeo = require('leaflet-geodesy'),
-    writable = false;
+    writable = false,
+    showStyle = true,
+    maki = '';
+
+d3.json("data/maki.json", function(error, json) {
+    for (i = 0; i < json.length; i++) {
+        console.log(json[i].icon);
+        maki += '<option value="' + json[i].icon + '">';
+    }
+});
 
 module.exports = function(context, readonly) {
 
@@ -25424,9 +25433,72 @@ function bindPopup(l) {
 
     if (!Object.keys(properties).length) properties = { '': '' };
 
+    if (l.feature && l.feature.geometry && writable) {
+        if (l.feature.geometry.type === 'Point') {
+            if (!('marker-color' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-color"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#7E7E7E"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('marker-size' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-size"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-size" value="medium"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+            }
+            if (!('marker-symbol' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-symbol"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-symbol" value=""' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'LineString' || l.feature.geometry.type === 'Polygon') {
+            if (!('stroke' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-width' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-width"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="number" min="0" step="0.1" value="2"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="1"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'Polygon') {
+            if (!('fill' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('fill-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="0.5"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+    }
+
     for (var key in properties) {
-        table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
-            '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        if ((key == 'marker-color' || key == 'stroke' || key == 'fill') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="color" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if (key == 'marker-size' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-size" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+        }
+        else if (key == 'marker-symbol' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-symbol" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+        }
+        else if (key == 'stroke-width' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="number" min="0" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if ((key == 'stroke-opacity' || key == 'fill-opacity') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="range" min="0" max="1" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else {
+            table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
     }
 
     if (l.feature && l.feature.geometry) {
@@ -25436,20 +25508,44 @@ function bindPopup(l) {
                 return total + L.latLng(pair[0][1], pair[0][0])
                     .distanceTo(L.latLng(pair[1][1], pair[1][0]));
             }, 0);
-            info += '<tr><td>meters</td><td>' + total.toFixed(2) +    '</td></tr>';
-            info += '<tr><td>miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
+            info += '<tr><td>Meters</td><td>' + total.toFixed(2) + '</td></tr>' +
+                    '<tr><td>Kilometers</td><td>' + (total / 1000).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Feet</td><td>' + (total / 0.3048).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Yards</td><td>' + (total / 0.9144).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Point') {
             info += '<tr><td>Latitude </td><td>' + l.feature.geometry.coordinates[1].toFixed(4) + '</td></tr>' +
                     '<tr><td>Longitude</td><td>' + l.feature.geometry.coordinates[0].toFixed(4) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Polygon') {
-            info += '<tr><td>Area km<sup>2</sup></td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>';
+          info += '<tr><td>Sq. Meters</td><td>' + (LGeo.area(l)).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Kilometers</td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Feet</td><td>' + (LGeo.area(l) / 0.092903).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Acres</td><td>' + (LGeo.area(l) / 4046.86).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Miles</td><td>' + (LGeo.area(l) / 2589990).toFixed(2) + '</td></tr>';
         }
         info += '</table>';
     }
 
+    var tabs = '<div class="tabs-ui">' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="properties" name="tab-group" checked="true">' +
+                        '<label for="properties">Properties</label>' +
+                        '<div class="content">' +
+                            (writable ? '<input type="checkbox" id="show-style" name="show-style" value="true" checked> Show style properties<br>' : '') +
+                            '<table class="marker-properties">' + table + '</table>' +
+                        '</div>' +
+                    '</div>' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="info" name="tab-group">' +
+                        '<label for="info">Info</label>' +
+                        '<div class="content">' +
+                            '<div class="marker-info">' + info + ' </div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+
     var content = '<div class="clearfix">' +
-        '<div class="marker-info">' + info + ' </div>' +
-        '<div class="marker-properties-limit"><table class="marker-properties">' + table + '</table></div>' +
+        '<div>' + tabs + '</div>' +
         (writable ? '<br /><div class="clearfix col12">' +
             '<div class="buttons-joined fl"><button class="add major">add row</button> ' +
             '<button class="save major">save</button> ' +
@@ -25461,6 +25557,22 @@ function bindPopup(l) {
         maxWidth: 500,
         maxHeight: 400
     }, l).setContent(content));
+
+    l.on('popupopen', function(e){
+        if (showStyle === false) {
+            d3.select('#show-style').property('checked', false);
+              d3.selectAll('.style-row').style('display','none');
+        }
+        d3.select('#show-style').on('click', function() {
+            if (this.checked) {
+                showStyle = true;
+                d3.selectAll('.style-row').style('display','');
+            } else {
+                showStyle = false;
+                d3.selectAll('.style-row').style('display','none');
+            }
+        });
+    });
 }
 
 },{"../lib/custom_hash.js":153,"../lib/popup":155,"leaflet-geodesy":37,"qs-hash":51}],172:[function(require,module,exports){

--- a/dist/site.js
+++ b/dist/site.js
@@ -25554,7 +25554,8 @@ function bindPopup(l) {
 
     l.bindPopup(L.popup({
         maxWidth: 500,
-        maxHeight: 400
+        maxHeight: 400,
+        autoPanPadding: [5, 45]
     }, l).setContent(content));
 
     l.on('popupopen', function(e){

--- a/dist/site.js
+++ b/dist/site.js
@@ -25329,7 +25329,6 @@ var popup = require('../lib/popup'),
 
 d3.json("data/maki.json", function(error, json) {
     for (i = 0; i < json.length; i++) {
-        console.log(json[i].icon);
         maki += '<option value="' + json[i].icon + '">';
     }
 });

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -25474,7 +25474,8 @@ function bindPopup(l) {
 
     l.bindPopup(L.popup({
         maxWidth: 500,
-        maxHeight: 400
+        maxHeight: 400,
+        autoPanPadding: [5, 45]
     }, l).setContent(content));
 
     l.on('popupopen', function(e){

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -25249,7 +25249,6 @@ var popup = require('../lib/popup'),
 
 d3.json("data/maki.json", function(error, json) {
     for (i = 0; i < json.length; i++) {
-        console.log(json[i].icon);
         maki += '<option value="' + json[i].icon + '">';
     }
 });

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -25243,7 +25243,16 @@ var popup = require('../lib/popup'),
     customHash = require('../lib/custom_hash.js'),
     qs = require('qs-hash'),
     LGeo = require('leaflet-geodesy'),
-    writable = false;
+    writable = false,
+    showStyle = true,
+    maki = '';
+
+d3.json("data/maki.json", function(error, json) {
+    for (i = 0; i < json.length; i++) {
+        console.log(json[i].icon);
+        maki += '<option value="' + json[i].icon + '">';
+    }
+});
 
 module.exports = function(context, readonly) {
 
@@ -25344,9 +25353,72 @@ function bindPopup(l) {
 
     if (!Object.keys(properties).length) properties = { '': '' };
 
+    if (l.feature && l.feature.geometry && writable) {
+        if (l.feature.geometry.type === 'Point') {
+            if (!('marker-color' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-color"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#7E7E7E"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('marker-size' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-size"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-size" value="medium"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+            }
+            if (!('marker-symbol' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-symbol"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-symbol" value=""' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'LineString' || l.feature.geometry.type === 'Polygon') {
+            if (!('stroke' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-width' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-width"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="number" min="0" step="0.1" value="2"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="1"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'Polygon') {
+            if (!('fill' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('fill-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="0.5"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+    }
+
     for (var key in properties) {
-        table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
-            '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        if ((key == 'marker-color' || key == 'stroke' || key == 'fill') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="color" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if (key == 'marker-size' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-size" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+        }
+        else if (key == 'marker-symbol' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-symbol" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+        }
+        else if (key == 'stroke-width' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="number" min="0" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if ((key == 'stroke-opacity' || key == 'fill-opacity') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="range" min="0" max="1" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else {
+            table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
     }
 
     if (l.feature && l.feature.geometry) {
@@ -25356,20 +25428,44 @@ function bindPopup(l) {
                 return total + L.latLng(pair[0][1], pair[0][0])
                     .distanceTo(L.latLng(pair[1][1], pair[1][0]));
             }, 0);
-            info += '<tr><td>meters</td><td>' + total.toFixed(2) +    '</td></tr>';
-            info += '<tr><td>miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
+            info += '<tr><td>Meters</td><td>' + total.toFixed(2) + '</td></tr>' +
+                    '<tr><td>Kilometers</td><td>' + (total / 1000).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Feet</td><td>' + (total / 0.3048).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Yards</td><td>' + (total / 0.9144).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Point') {
             info += '<tr><td>Latitude </td><td>' + l.feature.geometry.coordinates[1].toFixed(4) + '</td></tr>' +
                     '<tr><td>Longitude</td><td>' + l.feature.geometry.coordinates[0].toFixed(4) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Polygon') {
-            info += '<tr><td>Area km<sup>2</sup></td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>';
+          info += '<tr><td>Sq. Meters</td><td>' + (LGeo.area(l)).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Kilometers</td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Feet</td><td>' + (LGeo.area(l) / 0.092903).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Acres</td><td>' + (LGeo.area(l) / 4046.86).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Miles</td><td>' + (LGeo.area(l) / 2589990).toFixed(2) + '</td></tr>';
         }
         info += '</table>';
     }
 
+    var tabs = '<div class="tabs-ui">' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="properties" name="tab-group" checked="true">' +
+                        '<label for="properties">Properties</label>' +
+                        '<div class="content">' +
+                            (writable ? '<input type="checkbox" id="show-style" name="show-style" value="true" checked> Show style properties<br>' : '') +
+                            '<table class="marker-properties">' + table + '</table>' +
+                        '</div>' +
+                    '</div>' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="info" name="tab-group">' +
+                        '<label for="info">Info</label>' +
+                        '<div class="content">' +
+                            '<div class="marker-info">' + info + ' </div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+
     var content = '<div class="clearfix">' +
-        '<div class="marker-info">' + info + ' </div>' +
-        '<div class="marker-properties-limit"><table class="marker-properties">' + table + '</table></div>' +
+        '<div>' + tabs + '</div>' +
         (writable ? '<br /><div class="clearfix col12">' +
             '<div class="buttons-joined fl"><button class="add major">add row</button> ' +
             '<button class="save major">save</button> ' +
@@ -25381,6 +25477,22 @@ function bindPopup(l) {
         maxWidth: 500,
         maxHeight: 400
     }, l).setContent(content));
+
+    l.on('popupopen', function(e){
+        if (showStyle === false) {
+            d3.select('#show-style').property('checked', false);
+              d3.selectAll('.style-row').style('display','none');
+        }
+        d3.select('#show-style').on('click', function() {
+            if (this.checked) {
+                showStyle = true;
+                d3.selectAll('.style-row').style('display','');
+            } else {
+                showStyle = false;
+                d3.selectAll('.style-row').style('display','none');
+            }
+        });
+    });
 }
 
 },{"../lib/custom_hash.js":150,"../lib/popup":152,"leaflet-geodesy":37,"qs-hash":51}],170:[function(require,module,exports){

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -8,7 +8,6 @@ var popup = require('../lib/popup'),
 
 d3.json("data/maki.json", function(error, json) {
     for (i = 0; i < json.length; i++) {
-        console.log(json[i].icon);
         maki += '<option value="' + json[i].icon + '">';
     }
 });

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -233,7 +233,8 @@ function bindPopup(l) {
 
     l.bindPopup(L.popup({
         maxWidth: 500,
-        maxHeight: 400
+        maxHeight: 400,
+        autoPanPadding: [5, 45]
     }, l).setContent(content));
 
     l.on('popupopen', function(e){

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2,7 +2,16 @@ var popup = require('../lib/popup'),
     customHash = require('../lib/custom_hash.js'),
     qs = require('qs-hash'),
     LGeo = require('leaflet-geodesy'),
-    writable = false;
+    writable = false,
+    showStyle = true,
+    maki = '';
+
+d3.json("data/maki.json", function(error, json) {
+    for (i = 0; i < json.length; i++) {
+        console.log(json[i].icon);
+        maki += '<option value="' + json[i].icon + '">';
+    }
+});
 
 module.exports = function(context, readonly) {
 
@@ -103,9 +112,72 @@ function bindPopup(l) {
 
     if (!Object.keys(properties).length) properties = { '': '' };
 
+    if (l.feature && l.feature.geometry && writable) {
+        if (l.feature.geometry.type === 'Point') {
+            if (!('marker-color' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-color"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#7E7E7E"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('marker-size' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-size"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-size" value="medium"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+            }
+            if (!('marker-symbol' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="marker-symbol"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="text" list="marker-symbol" value=""' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'LineString' || l.feature.geometry.type === 'Polygon') {
+            if (!('stroke' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-width' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-width"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="number" min="0" step="0.1" value="2"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('stroke-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="stroke-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="1"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+        if (l.feature.geometry.type === 'Polygon') {
+            if (!('fill' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="color" value="#555555"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+            if (!('fill-opacity' in properties)) {
+                table += '<tr class="style-row"><th><input type="text" value="fill-opacity"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                    '<td><input type="range" min="0" max="1" step="0.1" value="0.5"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+            }
+        }
+    }
+
     for (var key in properties) {
-        table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
-            '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        if ((key == 'marker-color' || key == 'stroke' || key == 'fill') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="color" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if (key == 'marker-size' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-size" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+        }
+        else if (key == 'marker-symbol' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" list="marker-symbol" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-symbol">' + maki + '</datalist></td></tr>';
+        }
+        else if (key == 'stroke-width' && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="number" min="0" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else if ((key == 'stroke-opacity' || key == 'fill-opacity') && writable) {
+            table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="range" min="0" max="1" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
+        else {
+            table += '<tr><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+                '<td><input type="text" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+        }
     }
 
     if (l.feature && l.feature.geometry) {
@@ -115,20 +187,44 @@ function bindPopup(l) {
                 return total + L.latLng(pair[0][1], pair[0][0])
                     .distanceTo(L.latLng(pair[1][1], pair[1][0]));
             }, 0);
-            info += '<tr><td>meters</td><td>' + total.toFixed(2) +    '</td></tr>';
-            info += '<tr><td>miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
+            info += '<tr><td>Meters</td><td>' + total.toFixed(2) + '</td></tr>' +
+                    '<tr><td>Kilometers</td><td>' + (total / 1000).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Feet</td><td>' + (total / 0.3048).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Yards</td><td>' + (total / 0.9144).toFixed(2) + '</td></tr>' +
+                    '<tr><td>Miles</td><td>' + (total / 1609.34).toFixed(2) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Point') {
             info += '<tr><td>Latitude </td><td>' + l.feature.geometry.coordinates[1].toFixed(4) + '</td></tr>' +
                     '<tr><td>Longitude</td><td>' + l.feature.geometry.coordinates[0].toFixed(4) + '</td></tr>';
         } else if (l.feature.geometry.type === 'Polygon') {
-            info += '<tr><td>Area km<sup>2</sup></td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>';
+          info += '<tr><td>Sq. Meters</td><td>' + (LGeo.area(l)).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Kilometers</td><td>' + (LGeo.area(l) / 1000000).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Feet</td><td>' + (LGeo.area(l) / 0.092903).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Acres</td><td>' + (LGeo.area(l) / 4046.86).toFixed(2) + '</td></tr>' +
+                  '<tr><td>Sq. Miles</td><td>' + (LGeo.area(l) / 2589990).toFixed(2) + '</td></tr>';
         }
         info += '</table>';
     }
 
+    var tabs = '<div class="tabs-ui">' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="properties" name="tab-group" checked="true">' +
+                        '<label for="properties">Properties</label>' +
+                        '<div class="content">' +
+                            (writable ? '<input type="checkbox" id="show-style" name="show-style" value="true" checked> Show style properties<br>' : '') +
+                            '<table class="marker-properties">' + table + '</table>' +
+                        '</div>' +
+                    '</div>' +
+                    '<div class="tab">' +
+                        '<input type="radio" id="info" name="tab-group">' +
+                        '<label for="info">Info</label>' +
+                        '<div class="content">' +
+                            '<div class="marker-info">' + info + ' </div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+
     var content = '<div class="clearfix">' +
-        '<div class="marker-info">' + info + ' </div>' +
-        '<div class="marker-properties-limit"><table class="marker-properties">' + table + '</table></div>' +
+        '<div>' + tabs + '</div>' +
         (writable ? '<br /><div class="clearfix col12">' +
             '<div class="buttons-joined fl"><button class="add major">add row</button> ' +
             '<button class="save major">save</button> ' +
@@ -140,4 +236,20 @@ function bindPopup(l) {
         maxWidth: 500,
         maxHeight: 400
     }, l).setContent(content));
+
+    l.on('popupopen', function(e){
+        if (showStyle === false) {
+            d3.select('#show-style').property('checked', false);
+              d3.selectAll('.style-row').style('display','none');
+        }
+        d3.select('#show-style').on('click', function() {
+            if (this.checked) {
+                showStyle = true;
+                d3.selectAll('.style-row').style('display','');
+            } else {
+                showStyle = false;
+                d3.selectAll('.style-row').style('display','none');
+            }
+        });
+    });
 }


### PR DESCRIPTION
Provide HTML5 inputs to help users style features. Uses color type for marker-color, stroke & fill, number type for stroke-width, range slider for stroke-opacity & fill-opacity, and datalist for marker-size & marker-symbol. Falls back to text input for unsupported browsers.

Additional area and length measurements and metadata moved to Info tab to maximize space.

![image](https://cloud.githubusercontent.com/assets/753187/6181298/d10f53e8-b2fe-11e4-8b86-eeb38141d440.png)

