### PR TITLE
Offline error cleanup

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -26072,12 +26072,13 @@ module.exports = function fileBar(context) {
 
         var actions = [{
             title: 'Save',
-            action: saveAction,
+            action: (mapboxAPI || githubAPI) ? saveAction : function() {},
             children: exportFormats
         }, {
             title: 'New',
             action: function() {
-                window.open('/#new');
+                window.open(window.location.origin +
+                    window.location.pathname + '#new');
             }
         }, {
             title: 'Meta',

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -25992,12 +25992,13 @@ module.exports = function fileBar(context) {
 
         var actions = [{
             title: 'Save',
-            action: saveAction,
+            action: (mapboxAPI || githubAPI) ? saveAction : function() {},
             children: exportFormats
         }, {
             title: 'New',
             action: function() {
-                window.open('/#new');
+                window.open(window.location.origin +
+                    window.location.pathname + '#new');
             }
         }, {
             title: 'Meta',

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -57,12 +57,13 @@ module.exports = function fileBar(context) {
 
         var actions = [{
             title: 'Save',
-            action: saveAction,
+            action: (mapboxAPI || githubAPI) ? saveAction : function() {},
             children: exportFormats
         }, {
             title: 'New',
             action: function() {
-                window.open('/#new');
+                window.open(window.location.origin +
+                    window.location.pathname + '#new');
             }
         }, {
             title: 'Meta',


### PR DESCRIPTION
1. Anonymous gisting was erroring for offline users, so it's now disabled by default when API Endpoint is configured for Atlas Server.

2. `New` button now opens a new window with a relative url instead of `/#new` at root.

cc @tmcw 