### PR TITLE
add sudo false for faster travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
+sudo: false
 node_js:
   - 0.10


### PR DESCRIPTION
Since the tests for geojson.io do not need `sudo` during tests, we should add the `sudo: false` parameter to the travis.yml file. This will speed up test times on travis. 

ref: http://docs.travis-ci.com/user/workers/container-based-infrastructure/