### PR TITLE
Maintain editor scroll position after map change

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -25578,7 +25578,9 @@ module.exports = function(context) {
 
         context.dispatch.on('change.json', function(event) {
             if (event.source !== 'json') {
+                var scrollInfo = editor.getScrollInfo();
                 editor.setValue(JSON.stringify(context.data.get('map'), null, 2));
+                editor.scrollTo(scrollInfo.left, scrollInfo.top);
             }
         });
 

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -25498,7 +25498,9 @@ module.exports = function(context) {
 
         context.dispatch.on('change.json', function(event) {
             if (event.source !== 'json') {
+                var scrollInfo = editor.getScrollInfo();
                 editor.setValue(JSON.stringify(context.data.get('map'), null, 2));
+                editor.scrollTo(scrollInfo.left, scrollInfo.top);
             }
         });
 

--- a/src/panel/json.js
+++ b/src/panel/json.js
@@ -46,7 +46,9 @@ module.exports = function(context) {
 
         context.dispatch.on('change.json', function(event) {
             if (event.source !== 'json') {
+                var scrollInfo = editor.getScrollInfo();
                 editor.setValue(JSON.stringify(context.data.get('map'), null, 2));
+                editor.scrollTo(scrollInfo.left, scrollInfo.top);
             }
         });
 


### PR DESCRIPTION
This fixes a bug where, if you have scrolled down the JSON panel, made an edit, then added added a new feature on the map, the JSON panel would scroll back to the top instead of maintaining its position