### PR TITLE
Add OpenCycleMap option to layer switcher

### DIFF
--- a/src/ui/layer_switch.js
+++ b/src/ui/layer_switch.js
@@ -23,6 +23,11 @@ module.exports = function(context) {
                 title: 'Satellite',
                 layer: L.mapbox.tileLayer('tmcw.map-j5fsp01s')
             }, {
+                title: 'OCM',
+                layer: L.tileLayer('http://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png', {
+                   attribution: 'Maps &copy; <a href="http://www.thunderforest.com/">Thunderforest</a>, Data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                })
+            }, {
                 title: 'OSM',
                 layer: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
OpenCycleMap is a very popular OSM tileset. We would find this a very useful background to have available.