### PR TITLE
mapbox.places-permanent -> mapbox.places

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -26926,7 +26926,7 @@ module.exports = function(context, readonly) {
                 attributionControl: false
             })
             .setView([20, 0], 2)
-            .addControl(L.mapbox.geocoderControl('mapbox.places-permanent', {
+            .addControl(L.mapbox.geocoderControl('mapbox.places', {
                 position: 'topright'
             }));
 

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -26846,7 +26846,7 @@ module.exports = function(context, readonly) {
                 attributionControl: false
             })
             .setView([20, 0], 2)
-            .addControl(L.mapbox.geocoderControl('mapbox.places-permanent', {
+            .addControl(L.mapbox.geocoderControl('mapbox.places', {
                 position: 'topright'
             }));
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -23,7 +23,7 @@ module.exports = function(context, readonly) {
                 attributionControl: false
             })
             .setView([20, 0], 2)
-            .addControl(L.mapbox.geocoderControl('mapbox.places-permanent', {
+            .addControl(L.mapbox.geocoderControl('mapbox.places', {
                 position: 'topright'
             }));
 


### PR DESCRIPTION
re: #469 

Recent changes to the API token used in geojson.io makes using `mapbox.places-permanent` untenable.