### PR TITLE
Eliminate CSP warning for data: scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
       ;
     img-src
       'self'
+      data:
       *
       ;
     script-src


### PR DESCRIPTION
Need to explicitly add `data:` to the content security policy to avoid warnings on `data:` urls
`*` does not catch these, because it's treated as a source, not a protocol
see also http://stackoverflow.com/a/18449556/7620

relates to #499 
