### PR TITLE
Use the DOM to create tables for markers

### DIFF
--- a/data/share.html
+++ b/data/share.html
@@ -55,13 +55,29 @@ $.getJSON('map.geojson', function(geojson) {
 });
 
 function showProperties(l) {
-    var properties = l.toGeoJSON().properties, table = '';
+    var properties = l.toGeoJSON().properties;
+    var table = document.createElement('table');
+    table.setAttribute('class', 'marker-properties display')
     for (var key in properties) {
-        table += '<tr><th>' + key + '</th>' +
-            '<td>' + properties[key] + '</td></tr>';
+        var tr = createTableRows(key, properties[key]);
+        table.appendChild(tr);
     }
-    if (table) l.bindPopup('<table class="marker-properties display">' + table + '</table>');
+    if (table) l.bindPopup(table);
 }
+
+function createTableRows(key, value) {
+    var tr = document.createElement('tr');
+    var th = document.createElement('th');
+    var td = document.createElement('td');
+    key = document.createTextNode(key);
+    value = document.createTextNode(value);
+    th.appendChild(key);
+    td.appendChild(value);
+    tr.appendChild(th);
+    tr.appendChild(td);
+    return tr
+}
+
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "geojson-random": "0.1.0",
     "geojson2dsv": "0.0.0",
     "geojsonhint": "0.3.4",
-    "gist-map-browser": "0.2.0",
+    "gist-map-browser": "0.2.1",
     "github-file-browser": "0.6.1",
     "gtfs2geojson": "^1.0.0",
     "jsonlint": "1.6.0",


### PR DESCRIPTION
* Bumps gist-map-browser
* Uses the DOM to create tables for markers on `data/share.html`

/cc @tmcw 