### PR TITLE
Use :before pseudo element to increase hit size of points

### DIFF
--- a/css/marker.css
+++ b/css/marker.css
@@ -111,3 +111,28 @@ datalist {
     cursor: pointer;
     color: #199CF4;
 }
+
+
+/* Editable Points
+------------------------------------------------------- */
+
+.leaflet-editing-icon:before {
+    content: "";
+    display: block;
+    width: 525%;
+    height: 525%;
+    outline: 1px solid red;
+    z-index: 2;
+    position: relative;
+    margin-left: -212%;
+    margin-top: -212%;
+}
+
+.leaflet-editing-icon:hover {
+    border: 2px #464646 solid;
+    height: 10px !important;
+    width: 10px !important;
+    margin-top: -5px !important;
+    margin-left: -5px !important;
+    border-radius: 5px;
+}


### PR DESCRIPTION
This makes it easier to drag and drop points, rather than entire shapes.

__Gif demonstrating markers with larger hit targets__ 

![geojsondraggablemarkers](https://cloud.githubusercontent.com/assets/472589/26025228/d1cebf86-37da-11e7-82c4-0a2f45e0c4be.gif)

__Gif demonstrating larger hit targets and :hover styling to emphasis active marker__  

![geojsondraggablemarkerswithoutlines](https://cloud.githubusercontent.com/assets/472589/26025293/38eac858-37dc-11e7-8cc0-8d7f307667d6.gif)

Ref: #565