### PR TITLE
Fix for Gists failing to load when >1MB in size

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <![endif]-->
   <script src='lib/mapbox.js/latest/mapbox.js'></script>
   <script src='lib/raven.min.js'></script>
+  <script src='lib/jquery-1.10.2.min.js'></script>
   <meta http-equiv="Content-Security-Policy" content="
     default-src
       'self'

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -117,9 +117,9 @@ module.exports = function(context) {
 
                     var f = d.files[file];
                     if (f.truncated === true) {
-                        source.gist.loadRaw(f.raw_url, context, function(err, content) {
+                        source.gist.loadRaw(f.raw_url, function(err, content) {
                             if (err) return cb(err);
-                            return cb(err, xtend(d, { file: f.filename, content: JSON.parse(content) }));
+                            return cb(err, xtend(d, { file: f.filename, content: content }));
                         });
                     } else {
                         return cb(err, xtend(d, { file: f.filename, content: JSON.parse(f.content) }));
@@ -249,7 +249,17 @@ module.exports = function(context) {
                 var name = mapFile(d);
 
                 try {
-                    if (d.files[name].content) data.set({ map: JSON.parse(d.files[name].content) });
+                    var f = d.files[name];
+                    if(f.content) {
+                        if (f.truncated === true) {
+                            source.gist.loadRaw(f.raw_url, function(err, content) {
+                                if (err) throw err;
+                                data.set( { map: content });
+                            });
+                        } else {
+                            data.set( { map: JSON.parse(f.content) });
+                        }
+                    }
                 } catch (e) {
                     console.error(e);
                 }

--- a/src/source/gist.js
+++ b/src/source/gist.js
@@ -101,12 +101,16 @@ function load(id, context, callback) {
     function onError(err) { callback(err, null); }
 }
 
-function loadRaw(url, context, callback) {
-    context.user.signXHR(d3.text(url))
-        .on('load', onLoad)
-        .on('error', onError)
-        .get();
-
-    function onLoad(file) { callback(null, file); }
-    function onError(err) { callback(err, null); }
+function loadRaw(url, callback) {
+    $.ajax({
+        dataType: 'json',
+        url: url,
+        success: function (response) {
+            return callback(undefined, response);
+        },
+        error: function(jqXHR, e) {
+            console.error(e);
+            return callback(e);
+        }
+    });
 }


### PR DESCRIPTION
Currently attempting to load a Gist >1MB in size fails, as detailed in #573.  This addresses the issue by fetching the full contents of the Gist from the raw_url.  
