### PR TITLE
Export to GPX

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "smash": "0.0.11",
     "store": "1.3.14",
     "togeojson": "0.5.0",
+    "togpx": "0.5.4",
     "tokml": "0.3.0",
     "topojson": "1.6.8",
     "uglify-js": "2.4.1",

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -1,6 +1,7 @@
 var shpwrite = require('shp-write'),
     clone = require('clone'),
     geojson2dsv = require('geojson2dsv'),
+    togpx = require('togpx'),
     topojson = require('topojson'),
     saveAs = require('filesaver.js'),
     tokml = require('tokml'),
@@ -36,6 +37,9 @@ module.exports = function fileBar(context) {
     }, {
         title: 'TopoJSON',
         action: downloadTopo
+    }, {
+        title: 'GPX',
+        action: downloadGPX
     }, {
         title: 'CSV',
         action: downloadDSV
@@ -496,6 +500,15 @@ module.exports = function fileBar(context) {
             type: 'text/plain;charset=utf-8'
         }), 'map.topojson');
 
+    }
+
+    function downloadGPX() {
+        var content = togpx(clone(context.data.get('map')), 
+             {'creator': 'geojson.io'});
+
+        saveAs(new Blob([content], {
+            type: 'text/xml;charset=utf-8'
+        }), 'map.gpx');
     }
 
     function downloadGeoJSON() {


### PR DESCRIPTION
Adds a feature to export data to GPX format. This would be very useful as this is the only format supported for loading into OsmAnd.