### PR TITLE
Remove feedback link

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -55,7 +55,7 @@ module.exports = function(context, readonly) {
             .on('draw:created', created)
             .on('popupopen', popup(context));
 
-        context.map.attributionControl.setPrefix('<a target="_blank" href="http://tmcw.wufoo.com/forms/z7x4m1/">Feedback</a> | <a target="_blank" href="http://geojson.io/about.html">About</a>');
+        context.map.attributionControl.setPrefix('<a target="_blank" href="http://geojson.io/about.html">About</a>');
 
         function update() {
             var geojson = context.mapLayer.toGeoJSON();


### PR DESCRIPTION
The feedback link on geojson.io reports to my inbox, and I no longer maintain / have commit access / provide support for geojson.io.

Feel free to replace it with a link to a Mapbox-operated feedback mechanism, or anything else, but it's unfortunate for it to be essentially `/dev/null` right now.