### PR TITLE
upgrade d3 to version 3.517

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# node.js
+#
+node_modules/
+dist/*
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots
+
+# Bundle artifact
+*.jsbundle
+
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean-css": "~2.0.7",
     "clone": "0.1.16",
     "csv2geojson": "3.6.1",
-    "d3": "3.4.11",
+    "d3": "^3.5.17",
     "d3-metatable": "0.3.0",
     "detect-json-indent": "0.0.0",
     "escape-html": "^1.0.1",
@@ -46,7 +46,7 @@
     "xtend": "3.0.0"
   },
   "devDependencies": {
-    "browserify": "^14.0.0",
+    "browserify": "^14.5.0",
     "eslint": "^1.10.3",
     "tape": "~2.12.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ function geojsonIO() {
     context.repo = repo(context);
     context.router = router(context);
     context.user = user(context);
+    context.lang = 'en';
     return context;
 }
 

--- a/src/locale.json
+++ b/src/locale.json
@@ -1,0 +1,130 @@
+{
+	"Save": {
+		"en": "Save",
+		"vn": "Lưu"
+	},
+	"New": {
+		"en": "New",
+		"vn": "Tạo mới"
+	},
+	"Add map layer": {
+		"en": "Add map layer",
+		"vn": "Thêm lớp bản đồ"
+	},
+	"Add a custom tile layer": {
+		"en": "Add a custom tile layer",
+		"vn": "Thêm lớp nền"
+	},	
+	"Zoom to features": {
+		"en": "Zoom to features",
+		"vn": "Thu phóng tới các đặc tính "
+	},
+	"Zoom to the extent of all features": {
+		"en": "Zoom to the extent of all features",
+		"vn": "Thu phóng tới mức độ các đặc tính"
+	},
+	"Clear": {
+		"en": "Clear",
+		"vn": "Xóa"
+	},
+	"Delete all features from the map": {
+		"en": "Delete all features from the map",
+		"vn": "Xóa tất cả các đặc tính trên bản đồ"
+	},
+	"Are you sure you want to delete all features from this map?": {
+		"en": "Are you sure you want to delete all features from this map?",
+		"vn": "Bạn có chắc muốn xóa tất cả các đặc tính trên bản đồ?"
+	},
+	"Random: Points": {
+		"en": "Random: Points",
+		"vn": "Điểm ngẫu nhiên"
+	},
+	"Add random points to your map": {
+		"en": "Add random points to your map",
+		"vn": "Thêm điểm ngẫu nhiên vào bản đồ"
+	},
+	"Number of points (default: 100)": {
+		"en": "Number of points (default: 100)",
+		"vn": "Số điểm (mặc định: 100)"
+	},
+	"Add bboxes": {
+		"en": "Add bboxes",
+		"vn": "Thêm bboxes"
+	},
+	"Add bounding box members to all applicable GeoJSON objects": {
+		"en": "Add bounding box members to all applicable GeoJSON objects",
+		"vn": "Thêm bounding box members to all applicable GeoJSON objects"
+	},
+	"Flatten Multi Features": {
+		"en": "Flatten Multi Features",
+		"vn": "Flatten Multi Features"
+	},	
+	"Flatten MultiPolygons, MultiLines, and GeometryCollections into simple geometries": {
+		"en": "Flatten MultiPolygons, MultiLines, and GeometryCollections into simple geometries",
+		"vn": "Flatten MultiPolygons, MultiLines, and GeometryCollections into simple geometries"
+	},	
+	"Load encoded polyline": {
+		"en": "Load encoded polyline",
+		"vn": "Tải polyline mã hóa"
+	},	
+	"Decode and show an encoded polyline. Precision 5 is supported.": {
+		"en": "Decode and show an encoded polyline. Precision 5 is supported.",
+		"vn": "Giải mã và hiển thị một polyline được mã hóa. Độ chính xác 5 được hỗ trợ."
+	},	
+	"Load WKB Base64 Encoded String": {
+		"en": "Load WKB Base64 Encoded String",
+		"vn": "Load WKB mã hóa base64"
+	},	
+	"Decode and show WKX data": {
+		"en": "Decode and show WKX data",
+		"vn": "Decode and show WKX data"
+	},	
+	"Load WKB Hex Encoded String": {
+		"en": "Load WKB Hex Encoded String",
+		"vn": "Load WKB Hex Encoded String"
+	},	
+	"Decode and show WKX data": {
+		"en": "Decode and show WKX data",
+		"vn": "Decode and show WKX data"
+	},	
+	"Load WKT String": {
+		"en": "Load WKT String",
+		"vn": "Load WKT String"
+	},	
+	"Decode and show WKX data": {
+		"en": "Decode and show WKX data",
+		"vn": "Decode and show WKX data"
+	},	
+	"Open": {
+		"en": "Open",
+		"vn": "Mở"
+	},	
+	"File": {
+		"en": "File",
+		"vn": "File"
+	},	
+	"GeoJSON, TopoJSON, GTFS, KML, CSV, GPX and OSM XML supported": {
+		"en": "GeoJSON, TopoJSON, GTFS, KML, CSV, GPX and OSM XML supported",
+		"vn": "GeoJSON, TopoJSON, GTFS, KML, CSV, GPX and OSM XML supported"
+	},	
+	"CSV, GTFS, KML, GPX, and other filetypes": {
+		"en": "CSV, GTFS, KML, GPX, and other filetypes",
+		"vn": "CSV, GTFS, KML, GPX, and other filetypes"
+	},	
+	"unsaved": {
+		"en": "unsaved",
+		"vn": "chưa lưu"
+	},
+	"Commit": {
+		"en": "Commit",
+		"vn": "Commit"
+	},
+	"You must authenticate to use this API.": {
+		"en": "You must authenticate to use this API.",
+		"vn": "Bạn phải đăng nhập để sử dụng API này"
+	},
+	"New file name": {
+		"en": "New file name",
+		"vn": "Tên file mới"
+	}
+}

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -7,7 +7,8 @@ var shpwrite = require('shp-write'),
     githubBrowser = require('@mapbox/github-file-browser'),
     gistBrowser = require('@mapbox/gist-map-browser'),
     geojsonNormalize = require('geojson-normalize'),
-    wellknown = require('wellknown');
+    wellknown = require('wellknown'),
+    i18n_module = require('i18n-nodejs-browserify');
 
 var share = require('./share'),
     modal = require('./modal.js'),
@@ -17,6 +18,8 @@ var share = require('./share'),
     meta = require('../lib/meta.js'),
     saver = require('../ui/saver.js'),
     config = require('../config.js')(location.hostname);
+
+var locale = require('../locale.json');
 
 /**
  * This module provides the file picking & status bar above the map interface.
@@ -29,6 +32,8 @@ module.exports = function fileBar(context) {
     var mapboxAPI = /a\.tiles\.mapbox.com/.test(L.mapbox.config.HTTP_URL);
     var githubAPI = !!config.GithubAPI;
     var githubBase = githubAPI ? config.GithubAPI + '/api/v3': 'https://api.github.com';
+
+    var i18n = new i18n_module(context.lang, locale);
 
     var exportFormats = [{
         title: 'GeoJSON',
@@ -57,11 +62,11 @@ module.exports = function fileBar(context) {
     function bar(selection) {
 
         var actions = [{
-            title: 'Save',
+            title: i18n.__('Save'),
             action: (mapboxAPI || githubAPI) ? saveAction : function() {},
             children: exportFormats
         }, {
-            title: 'New',
+            title: i18n.__('New'),
             action: function() {
                 window.open(window.location.origin +
                     window.location.pathname + '#new');
@@ -71,8 +76,8 @@ module.exports = function fileBar(context) {
             action: function() {},
             children: [
                 {
-                    title: 'Add map layer',
-                    alt: 'Add a custom tile layer',
+                    title: i18n.__('Add map layer'),
+                    alt: i18n.__('Add a custom tile layer'),
                     action: function() {
                         var layerURL = prompt('Layer URL \n(http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg)');
                         if (layerURL === null) return;
@@ -82,63 +87,63 @@ module.exports = function fileBar(context) {
                     }
                 },
                 {
-                    title: 'Zoom to features',
-                    alt: 'Zoom to the extent of all features',
+                    title: i18n.__('Zoom to features'),
+                    alt: i18n.__('Zoom to the extent of all features'),
                     action: function() {
                         meta.zoomextent(context);
                     }
                 },
                 {
-                    title: 'Clear',
-                    alt: 'Delete all features from the map',
+                    title: i18n.__('Clear'),
+                    alt: i18n.__('Delete all features from the map'),
                     action: function() {
-                        if (confirm('Are you sure you want to delete all features from this map?')) {
+                        if (confirm(i18n.__('Are you sure you want to delete all features from this map?'))) {
                             meta.clear(context);
                         }
                     }
                 }, {
-                    title: 'Random: Points',
-                    alt: 'Add random points to your map',
+                    title: i18n.__('Random: Points'),
+                    alt: i18n.__('Add random points to your map'),
                     action: function() {
-                        var response = prompt('Number of points (default: 100)');
+                        var response = prompt(i18n.__('Number of points (default: 100)'));
                         if (response === null) return;
                         var count = parseInt(response, 10);
                         if (isNaN(count)) count = 100;
                         meta.random(context, count, 'point');
                     }
                 }, {
-                    title: 'Add bboxes',
-                    alt: 'Add bounding box members to all applicable GeoJSON objects',
+                    title: i18n.__('Add bboxes'),
+                    alt: i18n.__('Add bounding box members to all applicable GeoJSON objects'),
                     action: function() {
                         meta.bboxify(context);
                     }
                 }, {
-                    title: 'Flatten Multi Features',
-                    alt: 'Flatten MultiPolygons, MultiLines, and GeometryCollections into simple geometries',
+                    title: i18n.__('Flatten Multi Features'),
+                    alt: i18n.__('Flatten MultiPolygons, MultiLines, and GeometryCollections into simple geometries'),
                     action: function() {
                         meta.flatten(context);
                     }
                 }, {
-                    title: 'Load encoded polyline',
-                    alt: 'Decode and show an encoded polyline. Precision 5 is supported.',
+                    title: i18n.__('Load encoded polyline'),
+                    alt: i18n.__('Decode and show an encoded polyline. Precision 5 is supported.'),
                     action: function() {
                         meta.polyline(context);
                     }
                 }, {
-                    title: 'Load WKB Base64 Encoded String',
-                    alt: 'Decode and show WKX data',
+                    title: i18n.__('Load WKB Base64 Encoded String'),
+                    alt: i18n.__('Decode and show WKX data'),
                     action: function() {
                         meta.wkxBase64(context);
                     }
                 }, {
-                    title: 'Load WKB Hex Encoded String',
-                    alt: 'Decode and show WKX data',
+                    title: i18n.__('Load WKB Hex Encoded String'),
+                    alt: i18n.__('Decode and show WKX data'),
                     action: function() {
                         meta.wkxHex(context);
                     }
                 }, {
-                    title: 'Load WKT String',
-                    alt: 'Decode and show WKX data',
+                    title: i18n.__('Load WKT String'),
+                    alt: i18n.__('Decode and show WKX data'),
                     action: function() {
                         meta.wkxString(context);
                     }
@@ -148,47 +153,20 @@ module.exports = function fileBar(context) {
 
         if (mapboxAPI || githubAPI) {
             actions.unshift({
-                title: 'Open',
+                title: i18n.__('Open'),
                 children: [
                     {
-                        title: 'File',
-                        alt: 'GeoJSON, TopoJSON, GTFS, KML, CSV, GPX and OSM XML supported',
+                        title: i18n.__('File'),
+                        alt: i18n.__('GeoJSON, TopoJSON, GTFS, KML, CSV, GPX and OSM XML supported'),
                         action: blindImport
-                    }, {
-                        title: 'GitHub',
-                        alt: 'GeoJSON files in GitHub Repositories',
-                        authenticated: true,
-                        action: clickGitHubOpen
-                    }, {
-                        title: 'Gist',
-                        alt: 'GeoJSON files in GitHub Gists',
-                        authenticated: true,
-                        action: clickGist
                     }
                 ]
             });
-            actions[1].children.unshift({
-                    title: 'GitHub',
-                    alt: 'GeoJSON files in GitHub Repositories',
-                    authenticated: true,
-                    action: clickGitHubSave
-                }, {
-                    title: 'Gist',
-                    alt: 'GeoJSON files in GitHub Gists',
-                    authenticated: true,
-                    action: clickGistSave
-                });
-
-            if (mapboxAPI) actions.splice(3, 0, {
-                    title: 'Share',
-                    action: function() {
-                        context.container.call(share(context));
-                    }
-                });
+            
         } else {
             actions.unshift({
-                title: 'Open',
-                alt: 'CSV, GTFS, KML, GPX, and other filetypes',
+                title: i18n.__('Open'),
+                alt: i18n.__('CSV, GTFS, KML, GPX, and other filetypes'),
                 action: blindImport
             });
         }
@@ -228,7 +206,7 @@ module.exports = function fileBar(context) {
 
             var filename = name.append('span')
                 .attr('class', 'filename')
-                .text('unsaved');
+                .text(i18n.__('unsaved'));
         }
 
         function clickGistSave() {
@@ -250,7 +228,7 @@ module.exports = function fileBar(context) {
 
         function saveNoun(_) {
             buttons.filter(function(b) {
-                return b.title === 'Save';
+                return b.title === i18n.__('Save');
             }).select('span.title').text(_);
         }
 
@@ -262,7 +240,7 @@ module.exports = function fileBar(context) {
                     .enter()
                     .append('a')
                     .attr('title', function(d) {
-                        if (d.title == 'File' || d.title == 'GitHub' || d.title == 'Gist' || d.title == 'Add map layer' || d.title == 'Zoom to features' || d.title == 'Clear' || d.title == 'Random: Points' || d.title == 'Add bboxes' || d.title == 'Flatten Multi Features') return d.alt;
+                        if (d.title == i18n.__('File') || d.title == 'GitHub' || d.title == 'Gist' || d.title == i18n.__('Add map layer') || d.title == i18n.__('Zoom to features') || d.title == i18n.__('Clear') || d.title == i18n.__('Random: Points') || d.title == i18n.__('Add bboxes') || d.title == i18n.__('Flatten Multi Features')) return d.alt;
                     })
                     .text(function(d) {
                         return d.title;
@@ -276,7 +254,7 @@ module.exports = function fileBar(context) {
         context.dispatch.on('change.filebar', onchange);
 
         function clickGitHubOpen() {
-            if (!context.user.token()) return flash(context.container, 'You must authenticate to use this API.');
+            if (!context.user.token()) return flash(context.container, i18n.__('You must authenticate to use this API.'));
 
             var m = modal(d3.select('div.geojsonio'));
 
@@ -298,7 +276,7 @@ module.exports = function fileBar(context) {
                         throw new Error('last is invalid: ' + JSON.stringify(last));
                     }
                     if (!last.path.match(/\.(geo)?json/i)) {
-                        return alert('only GeoJSON files are supported from GitHub');
+                        return alert(i18n.__('only GeoJSON files are supported from GitHub'));
                     }
                     if (last.type === 'blob') {
                         githubBrowser.request('/repos/' + d[1].full_name +
@@ -318,7 +296,7 @@ module.exports = function fileBar(context) {
         }
 
         function clickGitHubSave() {
-            if (!context.user.token()) return flash(context.container, 'You must authenticate to use this API.');
+            if (!context.user.token()) return flash(context.container, i18n.__('You must authenticate to use this API.'));
 
             var m = modal(d3.select('div.geojsonio'));
 
@@ -341,7 +319,7 @@ module.exports = function fileBar(context) {
 
                     // New file
                     if (last.type === 'new')  {
-                        var filename = prompt('New file name');
+                        var filename = prompt(i18n.__('New file name'));
                         if (!filename) {
                             m.close();
                             return;
@@ -407,7 +385,7 @@ module.exports = function fileBar(context) {
         }
 
         function clickGist() {
-            if (!context.user.token()) return flash(context.container, 'You must authenticate to use this API.');
+            if (!context.user.token()) return flash(context.container, i18n.__('You must authenticate to use this API.'));
 
             var m = modal(d3.select('div.geojsonio'));
 
@@ -433,12 +411,12 @@ module.exports = function fileBar(context) {
                 type = data.type,
                 path = data.path;
             if (mapboxAPI || githubAPI) filename
-                .text(path ? path : 'unsaved')
+                .text(path ? path : i18n.__('unsaved'))
                 .classed('deemphasize', context.data.dirty);
             if (mapboxAPI || githubAPI) filetype
                 .attr('href', data.url)
                 .attr('class', sourceIcon(type));
-            saveNoun(type == 'github' ? 'Commit' : 'Save');
+            saveNoun(type == 'github' ? i18n.__('Commit') : i18n.__('Save'));
         }
 
         function blindImport() {


### PR DESCRIPTION
I got this error when I build the app. D3 version 3.4.11 is the reason because it refer to contextify version contextify@0.1.15.

I've upgraded d3 to version 3.5.17 to fix the error

```
npm ERR! contextify@0.1.15 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the contextify@0.1.15 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/vader/.npm/_logs/2018-08-06T04_50_31_571Z-debug.log
```