### PR TITLE
Requires Node versions < 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
   },
   "window": {
     "toolbar": false
-  }
+  },
+  "engines" : { "node" : "<8" }
 }


### PR DESCRIPTION
Node 7 was the current version at the time package.json was last modified and users report in #639 that the app doesn't install with 8+.