### PR TITLE
improve hot reload setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,15 @@
   "emeraldwalk.runonsave": {
     "commands": [
       {
-        "match": ".*",
-        "isAsync": true,
-        "cmd": "npx tailwindcss -i ./css/tailwind_src.css -o ./css/tailwind_dist.css && make"
+        "match": "lib|src|css/tailwind_src.css",
+        "cmd": "make"
       }
     ]
   },
-  "liveServer.settings.ignoreFiles" : [
-    "css/site_dist.css",
-    "css/site_src.css"
-  ]
-} 
+  "liveServer.settings.ignoreFiles": [
+    "lib/*",
+    "src/*",
+    "css/tailwind_src.css"
+  ],
+  "liveServer.settings.wait": 500
+}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLEANCSS = node_modules/.bin/cleancss
 UGLIFY = node_modules/.bin/uglifyjs
 LIBS = $(shell find lib -type f -name '*.js')
 
-all: dist/site.js dist/site.mobile.js dist/delegate.js
+all: dist/site.js dist/site.mobile.js dist/delegate.js css/tailwind_dist.css
 
 node_modules: package.json
 	npm install
@@ -63,6 +63,9 @@ dist/site.js: dist/lib.js src/index.js $(shell $(BROWSERIFY) --list src/index.js
 
 dist/site.mobile.js: dist/lib.js src/mobile.js $(shell $(BROWSERIFY) --list src/mobile.js)
 	$(BROWSERIFY) --noparse=src/source/local.js -t brfs -r topojson src/mobile.js > dist/site.mobile.js
+
+css/tailwind_dist.css:
+	npx tailwindcss -i ./css/tailwind_src.css -o ./css/tailwind_dist.css
 
 clean:
 	rm -f dist/*

--- a/README.md
+++ b/README.md
@@ -29,22 +29,19 @@ Install [browserify](https://github.com/substack/node-browserify)'ied libraries:
 
 `npm install`
 
-Browserify libraries, concat other libraries, build minimal d3:
+Browserify libraries, concat other libraries, build minimal d3, build tailwind css:
 
 `make`
 
-Build tailwind css:
-
-`npx tailwindcss -i ./css/tailwind_src.css -o ./css/tailwind_dist.css`
-
 Run a local server to preview your changes.
 
-### Development with VSCode
+### Development with VSCode (hot reloading)
 
-A streamlined dev workflow is possible with the `Live Server` and `Run on Save` VS Code extensions:
+An optimized development workflow is possible with the `Live Server` and `Run on Save` VS Code extensions.  Both have workspace-specific settings in `settings.json`:
 
 - Start a live server using `Live Server's` "Go Live" button
-- `Run on Save` reads it settings from `./vscode/settings.json` and will listen for changes to any file, then run both the `make` command and build the tailwind css file on each save.
+- `Run on Save` will watch `/lib`,`/src`, and `css/tailwind_src.css` and run `make` when any of them change.
+- `Live Server` will ignore `/lib`,`/src`, and `css/tailwind_src.css`, but will hot reload whenever any other file changes (including the files created by `make`)
 
 ## License
 


### PR DESCRIPTION
Improves the hot reloading configuration.

- `Run on save` only watches the directories and files that are processed by `make`, runs `make` when any of them change.
- `Live Server` ignores the same directories and files, but hot reloads on all others.
- Adds a `wait` setting to `Live Server` which prevents multiple sequential reloads as `make` saves multiple files simultaneously.
- Updates the readme with more info on this setup