### PR TITLE
restore simplestyle properties

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -32060,8 +32060,8 @@ module.exports = function (context, readonly) {
         type: 'fill',
         source: 'map-data',
         paint: {
-          'fill-color': color,
-          'fill-opacity': 0.3,
+          'fill-color': ['coalesce', ['get', 'fill'], color],
+          'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -32071,8 +32071,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -32082,8 +32083,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'LineString'],
       });
@@ -32208,7 +32210,7 @@ const addMarkers = (geojson, map, context, writable) => {
   
   pointFeatures.map((d, i) => {
     const marker = new ClickableMarker({
-      color: '#7e7e7e',
+      color: d.properties['marker-color'] || '#7e7e7e',
     })
       .setLngLat(d.geometry.coordinates)
       .onClick(() => {

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -32015,8 +32015,8 @@ module.exports = function (context, readonly) {
         type: 'fill',
         source: 'map-data',
         paint: {
-          'fill-color': color,
-          'fill-opacity': 0.3,
+          'fill-color': ['coalesce', ['get', 'fill'], color],
+          'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -32026,8 +32026,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -32037,8 +32038,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'LineString'],
       });
@@ -32163,7 +32165,7 @@ const addMarkers = (geojson, map, context, writable) => {
   
   pointFeatures.map((d, i) => {
     const marker = new ClickableMarker({
-      color: '#7e7e7e',
+      color: d.properties['marker-color'] || '#7e7e7e',
     })
       .setLngLat(d.geometry.coordinates)
       .onClick(() => {

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -221,8 +221,8 @@ module.exports = function (context, readonly) {
         type: 'fill',
         source: 'map-data',
         paint: {
-          'fill-color': color,
-          'fill-opacity': 0.3,
+          'fill-color': ['coalesce', ['get', 'fill'], color],
+          'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -232,8 +232,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'Polygon'],
       });
@@ -243,8 +244,9 @@ module.exports = function (context, readonly) {
         type: 'line',
         source: 'map-data',
         paint: {
-          'line-color': color,
-          'line-width': 2,
+          'line-color': ['coalesce', ['get', 'stroke'], color],
+          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
         },
         filter: ['==', ['geometry-type'], 'LineString'],
       });

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -43,7 +43,7 @@ const addMarkers = (geojson, map, context, writable) => {
   
   pointFeatures.map((d, i) => {
     const marker = new ClickableMarker({
-      color: '#7e7e7e',
+      color: d.properties['marker-color'] || '#7e7e7e',
     })
       .setLngLat(d.geometry.coordinates)
       .onClick(() => {


### PR DESCRIPTION
Restores simplestyle-spec styling based on the following properties:

points
- `marker-color`

linestrings
- `stroke`
- `stroke-width`
- `stroke-opacity` 

polygons
- `stroke`
- `stroke-width`
- `stroke-opacity` 
- `fill`
- `fill-opacity`

Closes #712 
