### PR TITLE
add osm raster tiles as a base layer option

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -31711,6 +31711,32 @@ module.exports = function (context) {
         title: 'Dark',
         style: 'mapbox://styles/mapbox/dark-v10',
       },
+      {
+        title: 'OSM',
+        style: {
+          name: 'osm',
+          version: 8,
+          sources: {
+            'osm-raster-tiles': {
+              type: 'raster',
+              tiles: [
+                'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+              ],
+              tileSize: 256,
+              attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'
+            }
+          }, 
+          layers: [
+            {
+              id: 'osm-raster-layer',
+              type: 'raster',
+              source: 'osm-raster-tiles',
+              minzoom: 0,
+              maxzoom: 22
+            }
+          ]
+        },
+      },
     ];
 
     var layerSwap = function (d) {

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -31666,6 +31666,32 @@ module.exports = function (context) {
         title: 'Dark',
         style: 'mapbox://styles/mapbox/dark-v10',
       },
+      {
+        title: 'OSM',
+        style: {
+          name: 'osm',
+          version: 8,
+          sources: {
+            'osm-raster-tiles': {
+              type: 'raster',
+              tiles: [
+                'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+              ],
+              tileSize: 256,
+              attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'
+            }
+          }, 
+          layers: [
+            {
+              id: 'osm-raster-layer',
+              type: 'raster',
+              source: 'osm-raster-tiles',
+              minzoom: 0,
+              maxzoom: 22
+            }
+          ]
+        },
+      },
     ];
 
     var layerSwap = function (d) {

--- a/src/ui/layer_switch.js
+++ b/src/ui/layer_switch.js
@@ -21,6 +21,32 @@ module.exports = function (context) {
         title: 'Dark',
         style: 'mapbox://styles/mapbox/dark-v10',
       },
+      {
+        title: 'OSM',
+        style: {
+          name: 'osm',
+          version: 8,
+          sources: {
+            'osm-raster-tiles': {
+              type: 'raster',
+              tiles: [
+                'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+              ],
+              tileSize: 256,
+              attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'
+            }
+          }, 
+          layers: [
+            {
+              id: 'osm-raster-layer',
+              type: 'raster',
+              source: 'osm-raster-tiles',
+              minzoom: 0,
+              maxzoom: 22
+            }
+          ]
+        },
+      },
     ];
 
     var layerSwap = function (d) {


### PR DESCRIPTION
Adds a style with a single raster source and layer to `layer_switch.js` to bring the OSM tileset back as a basemap option

<img width="1147" alt="geojson_io" src="https://user-images.githubusercontent.com/1833820/196961502-cbfbada9-fddf-4ffe-8e4e-4e224f990539.png">
