### PR TITLE
Add better error message when WebGL is not enabled

### DIFF
--- a/unsupported.html
+++ b/unsupported.html
@@ -17,7 +17,7 @@
 
 <body>
     <h1>Unsupported Browser or missing API</h1>
-    <p>Sorry, the browser you're currently using do not seems to support WebGL. It could be disabled, or it could be because it is out of date. Please check if WebGL is supported and enabled, or supported, or upgrade
+    <p>Sorry, the browser you're currently using does not seems to support WebGL. It could be that WebGL is disabled, or it could be that the browser is out of date. Please check if WebGL is supported and enabled, or supported, or upgrade
         to a modern browser in order to use the site.</p>
 </body>
 

--- a/unsupported.html
+++ b/unsupported.html
@@ -17,8 +17,7 @@
 
 <body>
     <h1>Unsupported Browser or missing API</h1>
-    <p>Sorry, the browser you're currently using does not seems to support WebGL. It could be that WebGL is disabled, or it could be that the browser is out of date. Please check if WebGL is supported and enabled, or supported, or upgrade
-        to a modern browser in order to use the site.</p>
+    <p>Sorry, the browser you're currently using does not seem to support WebGL. It could be that WebGL is disabled, or it could be that the browser is out of date. Please check if WebGL is supported and enabled, or supported, or upgrade to a modern browser in order to use the site.</p>
 </body>
 
 </html>

--- a/unsupported.html
+++ b/unsupported.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Unsupported Browser</title>
+    <title>Unsupported Browser or missing API</title>
     <meta http-equiv='content-type' content='text/html; charset=utf-8' />
     <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
     <style>
@@ -16,9 +16,8 @@
 </head>
 
 <body>
-    <h1>Unsupported Browser</h1>
-    <p>Sorry, the browser you're currently using is out of date and
-        incompatible with geojson.io. Please upgrade
+    <h1>Unsupported Browser or missing API</h1>
+    <p>Sorry, the browser you're currently using do not seems to support WebGL. It could be disabled, or it could be because it is out of date. Please check if WebGL is supported and enabled, or supported, or upgrade
         to a modern browser in order to use the site.</p>
 </body>
 


### PR DESCRIPTION
When I go to geojson.io, the message say my browser is out of date, which is weird given I run Firefox 105.0.2, and while 106.0 is out since 3 days, the real issue is that I disabled WebGL a long time ago. So I propose to change the error message to give a clue in case someone did like me (either disabled due to issue with driver stability, or disabled to avoid fingerprinting as it was done on some version of the tor browser)