### PR TITLE
update default view, fix mapDefault() check

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -29477,7 +29477,7 @@ module.exports = function(context) {
   }
 
   function mapDefault() {
-    return context.map.getZoom() == 2 || context.map.getCenter().equals(new L.LatLng(20, 0));
+    return context.map.getZoom() == 2 || JSON.stringify(context.map.getCenter()) === JSON.stringify({lng: 20, lat: 2});
   }
 
   function inlineJSON(data) {
@@ -31906,8 +31906,8 @@ module.exports = function (context, readonly) {
     context.map = new mapboxgl.Map({
       container: selection.node(),
       style: 'mapbox://styles/mapbox/streets-v11',
-      center: [-96, 37.8],
-      zoom: 3,
+      center: [20, 0],
+      zoom: 2,
       projection: 'globe',
       hash: 'map',
     });

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -29477,7 +29477,7 @@ module.exports = function(context) {
   }
 
   function mapDefault() {
-    return context.map.getZoom() == 2 || context.map.getCenter().equals(new L.LatLng(20, 0));
+    return context.map.getZoom() == 2 || JSON.stringify(context.map.getCenter()) === JSON.stringify({lng: 20, lat: 2});
   }
 
   function inlineJSON(data) {
@@ -31861,8 +31861,8 @@ module.exports = function (context, readonly) {
     context.map = new mapboxgl.Map({
       container: selection.node(),
       style: 'mapbox://styles/mapbox/streets-v11',
-      center: [-96, 37.8],
-      zoom: 3,
+      center: [20, 0],
+      zoom: 2,
       projection: 'globe',
       hash: 'map',
     });

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
   }
 
   function mapDefault() {
-    return context.map.getZoom() == 2 || context.map.getCenter().equals(new L.LatLng(20, 0));
+    return context.map.getZoom() == 2 || JSON.stringify(context.map.getCenter()) === JSON.stringify({lng: 20, lat: 2});
   }
 
   function inlineJSON(data) {

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -41,8 +41,8 @@ module.exports = function (context, readonly) {
     context.map = new mapboxgl.Map({
       container: selection.node(),
       style: 'mapbox://styles/mapbox/streets-v11',
-      center: [-96, 37.8],
-      zoom: 3,
+      center: [20, 0],
+      zoom: 2,
       projection: 'globe',
       hash: 'map',
     });


### PR DESCRIPTION
Updates the function that checks whether the map has moved from its default position which previously depended on Leaflet.

To test, load the local server with `#id=github:ebrelsford/geojson-examples/blob/master/brooklyn.geojson` appended to the URL.

Note: There is still a race condition that may prevent the markers from showing up in the above example, this is logged in #728 

This PR will get rid of the Leaflet error, but the map data may not display until we address the race condition.

Fixes #724 