### PR TITLE
prevent line or polygon popup if marker was clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2022-10-24
-
+* prevent line or polygon popup if marker was clicked (#730)
 * Fix the handling of points in MultiPoint and GeometryCollection geometries (#736)
 
 ## 2022-10-21

--- a/dist/site.js
+++ b/dist/site.js
@@ -41459,6 +41459,7 @@ const { EditControl, SaveCancelControl, TrashControl } = require('./controls');
 const { addIds, addMarkers, geojsonToLayer, bindPopup } = require('./util');
 
 let writable = false;
+let drawing = false;
 
 const dummyGeojson = {
   type: 'FeatureCollection',
@@ -41524,6 +41525,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_point');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_point'],
@@ -41531,6 +41533,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_line_string');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_line'],
@@ -41538,6 +41541,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_polygon');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_polygon'],
@@ -41545,6 +41549,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_rectangle');
             },
             classes: [
@@ -41727,19 +41732,24 @@ module.exports = function (context, readonly) {
       }
     };
 
+    const handleLinestringOrPolygonClick = (e) => {
+      // prevent this popup from opening when the original click was on a marker
+      const el = e.originalEvent.target;
+      if (el.nodeName !== 'CANVAS') return;
+      // prevent this popup from opening when drawing new features
+      if (drawing) return;
+ 
+      bindPopup(e, context, writable);
+    };
+
     context.map.on('load', () => {
       context.map.on('mouseenter', 'map-data-fill', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-fill', maybeResetCursor);
       context.map.on('mouseenter', 'map-data-line', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-line', maybeResetCursor);
 
-      context.map.on('click', 'map-data-fill', (e) => {
-        bindPopup(e, context, writable);
-      });
-
-      context.map.on('click', 'map-data-line', (e) => {
-        bindPopup(e, context, writable);
-      });
+      context.map.on('click', 'map-data-fill', handleLinestringOrPolygonClick);
+      context.map.on('click', 'map-data-line', handleLinestringOrPolygonClick);
     });
 
     context.map.on('draw.create', created);
@@ -41754,6 +41764,13 @@ module.exports = function (context, readonly) {
     function created(e) {
       context.Draw.deleteAll();
       update(stripIds(e.features));
+
+      // delay setting drawing back to false after a drawn feature is created
+      // this allows the map click handler to ignore the click and prevents a popup
+      // if the drawn feature endeds within an existing feature
+      setTimeout(() => {
+        drawing = false;
+      }, 500);
     }
 
     function update(features) {

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -7,6 +7,7 @@ const { EditControl, SaveCancelControl, TrashControl } = require('./controls');
 const { addIds, addMarkers, geojsonToLayer, bindPopup } = require('./util');
 
 let writable = false;
+let drawing = false;
 
 const dummyGeojson = {
   type: 'FeatureCollection',
@@ -72,6 +73,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_point');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_point'],
@@ -79,6 +81,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_line_string');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_line'],
@@ -86,6 +89,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_polygon');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_polygon'],
@@ -93,6 +97,7 @@ module.exports = function (context, readonly) {
           {
             on: 'click',
             action: () => {
+              drawing = true;
               context.Draw.changeMode('draw_rectangle');
             },
             classes: [
@@ -275,19 +280,24 @@ module.exports = function (context, readonly) {
       }
     };
 
+    const handleLinestringOrPolygonClick = (e) => {
+      // prevent this popup from opening when the original click was on a marker
+      const el = e.originalEvent.target;
+      if (el.nodeName !== 'CANVAS') return;
+      // prevent this popup from opening when drawing new features
+      if (drawing) return;
+ 
+      bindPopup(e, context, writable);
+    };
+
     context.map.on('load', () => {
       context.map.on('mouseenter', 'map-data-fill', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-fill', maybeResetCursor);
       context.map.on('mouseenter', 'map-data-line', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-line', maybeResetCursor);
 
-      context.map.on('click', 'map-data-fill', (e) => {
-        bindPopup(e, context, writable);
-      });
-
-      context.map.on('click', 'map-data-line', (e) => {
-        bindPopup(e, context, writable);
-      });
+      context.map.on('click', 'map-data-fill', handleLinestringOrPolygonClick);
+      context.map.on('click', 'map-data-line', handleLinestringOrPolygonClick);
     });
 
     context.map.on('draw.create', created);
@@ -302,6 +312,13 @@ module.exports = function (context, readonly) {
     function created(e) {
       context.Draw.deleteAll();
       update(stripIds(e.features));
+
+      // delay setting drawing back to false after a drawn feature is created
+      // this allows the map click handler to ignore the click and prevents a popup
+      // if the drawn feature endeds within an existing feature
+      setTimeout(() => {
+        drawing = false;
+      }, 500);
     }
 
     function update(features) {


### PR DESCRIPTION
Prevents two popups from appearing when a marker located within a polygon is clicked.

Closes #710

Also adds `drawing` state boolean to prevent popup from showing when a drawn feature's last vertex is within an existing geometry.  (simple example: draw a new point feature within an existing polygon, the polygon's popup will open)