### PR TITLE
check for source instead of isStyleLoaded()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2022-10-25
+
+* Fix a bug that was checking for map load in an unreliable way before adding data from externally loaded geojson (#733)
+
 ## 2022-10-24
 
 * Fix the handling of points in MultiPoint and GeometryCollection geometries (#736)

--- a/dist/site.js
+++ b/dist/site.js
@@ -41877,9 +41877,9 @@ const addMarkers = (geojson, context, writable) => {
 };
 
 function geojsonToLayer(geojson, context, writable) {
-  if (context.map.isStyleLoaded()) {
-    context.map.getSource('map-data').setData(addIds(geojson));
-  
+  const dataLoaded = context.map.getSource('map-data');
+  if (dataLoaded) {
+    dataLoaded.setData(addIds(geojson));
     addMarkers(geojson, context, writable);
   }
 }

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -41832,9 +41832,9 @@ const addMarkers = (geojson, context, writable) => {
 };
 
 function geojsonToLayer(geojson, context, writable) {
-  if (context.map.isStyleLoaded()) {
-    context.map.getSource('map-data').setData(addIds(geojson));
-  
+  const dataLoaded = context.map.getSource('map-data');
+  if (dataLoaded) {
+    dataLoaded.setData(addIds(geojson));
     addMarkers(geojson, context, writable);
   }
 }

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -98,9 +98,9 @@ const addMarkers = (geojson, context, writable) => {
 };
 
 function geojsonToLayer(geojson, context, writable) {
-  if (context.map.isStyleLoaded()) {
-    context.map.getSource('map-data').setData(addIds(geojson));
-  
+  const dataLoaded = context.map.getSource('map-data');
+  if (dataLoaded) {
+    dataLoaded.setData(addIds(geojson));
     addMarkers(geojson, context, writable);
   }
 }


### PR DESCRIPTION
Closes #728 

`geojsonToLayer()` is fired when `context.data` changes, triggering a `map.setData()` and re-rendering of markers. 

It was checking for `map.isStyleLoaded()` which was returning false and preventing the initial setData() from  running.  