### PR TITLE
handle markers for Point, MultiPoint, and GeometryCollection geometries

### DIFF
--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -41757,24 +41757,60 @@ const addIds = (geojson) => {
 };
   
 const addMarkers = (geojson, context, writable) => {
+  // remove all existing markers
   markers.forEach((d) => {
     d.remove();
   });
   let pointFeatures = [];
-  let pointFeaturesIndices = [];
-  // add markers
-  if (geojson.features) {
-    geojson.features.forEach((d, i) => {
-      if (d.geometry.type === 'Point') {
-        pointFeatures.push(d);
-        pointFeaturesIndices.push(i);
-      }
+
+  // wrap point geometry in a feature and push
+  const handlePointGeometry = (geometry, properties, id) => {
+    pointFeatures.push({
+      type: 'Feature',
+      id,
+      geometry,
+      properties
     });
+  };
+
+  // the three geometry types that may need markers are Point, MultiPoint, or GeometryCollection
+  // for each point to be rendered, create a separate feature with the parent's properties
+  // so that they will show up properly in the popup
+  // TODO: indicate in the popup and/or elsewhere when a point is part of a MultiPoint or GeometryCollection
+  const handleGeometry = (geometry, properties, index) => {
+    if (geometry.type === 'Point') {
+      handlePointGeometry(geometry, properties, index);
+    }
+
+    if (geometry.type === 'MultiPoint') {
+      geometry.coordinates.forEach((coordinatePair) => {
+        handlePointGeometry({
+          type: 'Point',
+          coordinates: coordinatePair
+        }, properties, index);
+      });
+    }
+
+    if (geometry.type === 'GeometryCollection') {
+      geometry.geometries.forEach((geometry) => {
+        handleGeometry(geometry, properties, index);
+      });
+    }
+  };
+
+  switch (geojson.type) {
+  case 'FeatureCollection':
+    geojson.features.forEach((d, i) => {
+      const { geometry, properties } = d;
+      handleGeometry(geometry, properties, i);
+    });
+    break;
   }
-  
+
   if (pointFeatures.length === 0) {
     return;
   }
+
   
   pointFeatures.map((d, i) => {
     const marker = new ClickableMarker({
@@ -41785,12 +41821,7 @@ const addMarkers = (geojson, context, writable) => {
         bindPopup(
           {
             lngLat: d.geometry.coordinates,
-            features: [
-              {
-                id: pointFeaturesIndices[i],
-                ...d,
-              },
-            ],
+            features: [d],
           },
           context,
           writable
@@ -41800,6 +41831,7 @@ const addMarkers = (geojson, context, writable) => {
     markers.push(marker);
   });
 };
+
 function geojsonToLayer(geojson, context, writable) {
   if (context.map.isStyleLoaded()) {
     context.map.getSource('map-data').setData(addIds(geojson));

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -22,24 +22,60 @@ const addIds = (geojson) => {
 };
   
 const addMarkers = (geojson, context, writable) => {
+  // remove all existing markers
   markers.forEach((d) => {
     d.remove();
   });
   let pointFeatures = [];
-  let pointFeaturesIndices = [];
-  // add markers
-  if (geojson.features) {
-    geojson.features.forEach((d, i) => {
-      if (d.geometry.type === 'Point') {
-        pointFeatures.push(d);
-        pointFeaturesIndices.push(i);
-      }
+
+  // wrap point geometry in a feature and push
+  const handlePointGeometry = (geometry, properties, id) => {
+    pointFeatures.push({
+      type: 'Feature',
+      id,
+      geometry,
+      properties
     });
+  };
+
+  // the three geometry types that may need markers are Point, MultiPoint, or GeometryCollection
+  // for each point to be rendered, create a separate feature with the parent's properties
+  // so that they will show up properly in the popup
+  // TODO: indicate in the popup and/or elsewhere when a point is part of a MultiPoint or GeometryCollection
+  const handleGeometry = (geometry, properties, index) => {
+    if (geometry.type === 'Point') {
+      handlePointGeometry(geometry, properties, index);
+    }
+
+    if (geometry.type === 'MultiPoint') {
+      geometry.coordinates.forEach((coordinatePair) => {
+        handlePointGeometry({
+          type: 'Point',
+          coordinates: coordinatePair
+        }, properties, index);
+      });
+    }
+
+    if (geometry.type === 'GeometryCollection') {
+      geometry.geometries.forEach((geometry) => {
+        handleGeometry(geometry, properties, index);
+      });
+    }
+  };
+
+  switch (geojson.type) {
+  case 'FeatureCollection':
+    geojson.features.forEach((d, i) => {
+      const { geometry, properties } = d;
+      handleGeometry(geometry, properties, i);
+    });
+    break;
   }
-  
+
   if (pointFeatures.length === 0) {
     return;
   }
+
   
   pointFeatures.map((d, i) => {
     const marker = new ClickableMarker({
@@ -50,12 +86,7 @@ const addMarkers = (geojson, context, writable) => {
         bindPopup(
           {
             lngLat: d.geometry.coordinates,
-            features: [
-              {
-                id: pointFeaturesIndices[i],
-                ...d,
-              },
-            ],
+            features: [d],
           },
           context,
           writable
@@ -65,6 +96,7 @@ const addMarkers = (geojson, context, writable) => {
     markers.push(marker);
   });
 };
+
 function geojsonToLayer(geojson, context, writable) {
   if (context.map.isStyleLoaded()) {
     context.map.getSource('map-data').setData(addIds(geojson));


### PR DESCRIPTION
Updates `addMarkers()` to properly render markers from each of `Point`, `MultiPoint`, and `GeometryCollection` geometries.

- Assumes geojson is always a FeatureCollection (see #732)
- Properties are passed down from MultiPoints and GeometryCollections into a new Feature with Point geometry which will power the marker.  The properties will show up in the popup, and editing properties in a popup will edit them for the entire MultiPoint or GeometryCollection.

Closes #722