### PR TITLE
fix style load check

### DIFF
--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -57953,7 +57953,8 @@ function _getData() {
     dirty: false,
     source: null,
     meta: null,
-    type: 'local'
+    type: 'local',
+    mapStyleLoaded: false
   };
 }
 
@@ -58557,6 +58558,10 @@ module.exports.adduserlayer = function(context, _url, _name) {
     // make this layer's button active
     d3.select('.layer-switch .active').classed('active', false);
     d3.select('.user-layer-button').classed('active', true);
+
+    context.data.set({
+      mapStyleLoaded: true
+    });
   }
 
   // append a button to the existing style selection UI
@@ -59925,7 +59930,7 @@ module.exports = function fileBar(context) {
             alt: 'Add a custom tile layer',
             action: function () {
               var layerURL = prompt(
-                'Layer URL\ne.g. http://stamen-tiles-b.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
+                'Layer URL\ne.g. https://stamen-tiles-b.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
               );
               if (layerURL === null) return;
               var layerName = prompt('Layer name');
@@ -60539,7 +60544,12 @@ module.exports = function (context) {
         const { title, style } = d3.select(clicked).datum();
 
         context.map.setStyle(style);
+
         context.storage.set('style', title);
+
+        context.data.set({
+          mapStyleLoaded: true
+        });
       }
     };
 
@@ -60870,55 +60880,61 @@ module.exports = function (context, readonly) {
       });
     }
 
-    context.map.on('style.load', () => {
-      const { name } = context.map.getStyle();
-      let color = DARK_FEATURE_COLOR;
-      if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
-        color = LIGHT_FEATURE_COLOR;
+    context.map.on('idle', () => {
+      if (context.data.get('mapStyleLoaded') && !context.map.getSource('map-data')) {
+        const { name } = context.map.getStyle();
+        let color = DARK_FEATURE_COLOR;
+        if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
+          color = LIGHT_FEATURE_COLOR;
+        }
+        context.map.setFog({});
+  
+        context.map.addSource('map-data', {
+          type: 'geojson',
+          data: addIds(context.data.get('map')) || dummyGeojson,
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-fill',
+          type: 'fill',
+          source: 'map-data',
+          paint: {
+            'fill-color': ['coalesce', ['get', 'fill'], color],
+            'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
+          },
+          filter: ['==', ['geometry-type'], 'Polygon'],
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-fill-outline',
+          type: 'line',
+          source: 'map-data',
+          paint: {
+            'line-color': ['coalesce', ['get', 'stroke'], color],
+            'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+          },
+          filter: ['==', ['geometry-type'], 'Polygon'],
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-line',
+          type: 'line',
+          source: 'map-data',
+          paint: {
+            'line-color': ['coalesce', ['get', 'stroke'], color],
+            'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+          },
+          filter: ['==', ['geometry-type'], 'LineString'],
+        });
+  
+        addMarkers(context.data.get('map'), context, writable);
+
+        context.data.set({
+          mapStyleLoaded: false
+        });
       }
-      context.map.setFog({});
-
-      context.map.addSource('map-data', {
-        type: 'geojson',
-        data: addIds(context.data.get('map')) || dummyGeojson,
-      });
-
-      context.map.addLayer({
-        id: 'map-data-fill',
-        type: 'fill',
-        source: 'map-data',
-        paint: {
-          'fill-color': ['coalesce', ['get', 'fill'], color],
-          'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
-        },
-        filter: ['==', ['geometry-type'], 'Polygon'],
-      });
-
-      context.map.addLayer({
-        id: 'map-data-fill-outline',
-        type: 'line',
-        source: 'map-data',
-        paint: {
-          'line-color': ['coalesce', ['get', 'stroke'], color],
-          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
-        },
-        filter: ['==', ['geometry-type'], 'Polygon'],
-      });
-
-      context.map.addLayer({
-        id: 'map-data-line',
-        type: 'line',
-        source: 'map-data',
-        paint: {
-          'line-color': ['coalesce', ['get', 'stroke'], color],
-          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
-        },
-        filter: ['==', ['geometry-type'], 'LineString'],
-      });
-
-      addMarkers(context.data.get('map'), context, writable);
     });
 
     // only show projection toggle on zoom < 6
@@ -60954,6 +60970,9 @@ module.exports = function (context, readonly) {
     };
 
     context.map.on('load', () => {
+      context.data.set({
+        mapStyleLoaded: true
+      });     
       context.map.on('mouseenter', 'map-data-fill', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-fill', maybeResetCursor);
       context.map.on('mouseenter', 'map-data-line', maybeSetCursorToPointer);

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -16,7 +16,8 @@ function _getData() {
     dirty: false,
     source: null,
     meta: null,
-    type: 'local'
+    type: 'local',
+    mapStyleLoaded: false
   };
 }
 

--- a/src/lib/meta.js
+++ b/src/lib/meta.js
@@ -41,6 +41,10 @@ module.exports.adduserlayer = function(context, _url, _name) {
     // make this layer's button active
     d3.select('.layer-switch .active').classed('active', false);
     d3.select('.user-layer-button').classed('active', true);
+
+    context.data.set({
+      mapStyleLoaded: true
+    });
   }
 
   // append a button to the existing style selection UI

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -85,7 +85,7 @@ module.exports = function fileBar(context) {
             alt: 'Add a custom tile layer',
             action: function () {
               var layerURL = prompt(
-                'Layer URL\ne.g. http://stamen-tiles-b.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
+                'Layer URL\ne.g. https://stamen-tiles-b.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
               );
               if (layerURL === null) return;
               var layerName = prompt('Layer name');

--- a/src/ui/layer_switch.js
+++ b/src/ui/layer_switch.js
@@ -20,7 +20,12 @@ module.exports = function (context) {
         const { title, style } = d3.select(clicked).datum();
 
         context.map.setStyle(style);
+
         context.storage.set('style', title);
+
+        context.data.set({
+          mapStyleLoaded: true
+        });
       }
     };
 

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -214,55 +214,61 @@ module.exports = function (context, readonly) {
       });
     }
 
-    context.map.on('style.load', () => {
-      const { name } = context.map.getStyle();
-      let color = DARK_FEATURE_COLOR;
-      if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
-        color = LIGHT_FEATURE_COLOR;
+    context.map.on('idle', () => {
+      if (context.data.get('mapStyleLoaded') && !context.map.getSource('map-data')) {
+        const { name } = context.map.getStyle();
+        let color = DARK_FEATURE_COLOR;
+        if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
+          color = LIGHT_FEATURE_COLOR;
+        }
+        context.map.setFog({});
+  
+        context.map.addSource('map-data', {
+          type: 'geojson',
+          data: addIds(context.data.get('map')) || dummyGeojson,
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-fill',
+          type: 'fill',
+          source: 'map-data',
+          paint: {
+            'fill-color': ['coalesce', ['get', 'fill'], color],
+            'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
+          },
+          filter: ['==', ['geometry-type'], 'Polygon'],
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-fill-outline',
+          type: 'line',
+          source: 'map-data',
+          paint: {
+            'line-color': ['coalesce', ['get', 'stroke'], color],
+            'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+          },
+          filter: ['==', ['geometry-type'], 'Polygon'],
+        });
+  
+        context.map.addLayer({
+          id: 'map-data-line',
+          type: 'line',
+          source: 'map-data',
+          paint: {
+            'line-color': ['coalesce', ['get', 'stroke'], color],
+            'line-width': ['coalesce', ['get', 'stroke-width'], 2],
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+          },
+          filter: ['==', ['geometry-type'], 'LineString'],
+        });
+  
+        addMarkers(context.data.get('map'), context, writable);
+
+        context.data.set({
+          mapStyleLoaded: false
+        });
       }
-      context.map.setFog({});
-
-      context.map.addSource('map-data', {
-        type: 'geojson',
-        data: addIds(context.data.get('map')) || dummyGeojson,
-      });
-
-      context.map.addLayer({
-        id: 'map-data-fill',
-        type: 'fill',
-        source: 'map-data',
-        paint: {
-          'fill-color': ['coalesce', ['get', 'fill'], color],
-          'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
-        },
-        filter: ['==', ['geometry-type'], 'Polygon'],
-      });
-
-      context.map.addLayer({
-        id: 'map-data-fill-outline',
-        type: 'line',
-        source: 'map-data',
-        paint: {
-          'line-color': ['coalesce', ['get', 'stroke'], color],
-          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
-        },
-        filter: ['==', ['geometry-type'], 'Polygon'],
-      });
-
-      context.map.addLayer({
-        id: 'map-data-line',
-        type: 'line',
-        source: 'map-data',
-        paint: {
-          'line-color': ['coalesce', ['get', 'stroke'], color],
-          'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-          'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
-        },
-        filter: ['==', ['geometry-type'], 'LineString'],
-      });
-
-      addMarkers(context.data.get('map'), context, writable);
     });
 
     // only show projection toggle on zoom < 6
@@ -298,6 +304,9 @@ module.exports = function (context, readonly) {
     };
 
     context.map.on('load', () => {
+      context.data.set({
+        mapStyleLoaded: true
+      });     
       context.map.on('mouseenter', 'map-data-fill', maybeSetCursorToPointer);
       context.map.on('mouseleave', 'map-data-fill', maybeResetCursor);
       context.map.on('mouseenter', 'map-data-line', maybeSetCursorToPointer);


### PR DESCRIPTION

Instead of listening for `style.load`, which is not part of the public api, we add `mapStyleLoaded` as a boolean to `context.data`.  When the user clicks a different style, `mapStyleLoaded` is set to `true`.  On the map `idle` event, if `mapStyleLoaded` is true and the map does not already contain the working dataset sources and layers, we add them and set `mapStyleLoaded` to false.  

This method also works when toggling between a user-added raster layer and any of the existing base styles (fixing #740)