### PR TITLE
add keybindings for draw mode changes and trash

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -102,11 +102,7 @@ p.intro-hint:hover {
 }
 
 .top .buttons {
-<<<<<<< HEAD
   margin-left: 40px;
-=======
-  margin-left: 28px;
->>>>>>> cdb58de2 (add circle drawing mode, add title tooltips for draw buttons)
   height: 40px;
 }
 

--- a/dist/site.js
+++ b/dist/site.js
@@ -60075,7 +60075,7 @@ module.exports = function(context) {
 var marked = require('marked');
 
 module.exports = function(context) {
-    var html = Buffer("PGgyPkhlbHA8L2gyPgoKPHA+PHN0cm9uZz5nZW9qc29uLmlvPC9zdHJvbmc+IGlzIGEgcXVpY2ssIHNpbXBsZSB0b29sIGZvciBjcmVhdGluZywKICAgIHZpZXdpbmcsIGFuZCBzaGFyaW5nIG1hcHMuIGdlb2pzb24uaW8gaXMgbmFtZWQgYWZ0ZXIgPGEgaHJlZj0naHR0cDovL2dlb2pzb24ub3JnLycgdGFyZ2V0PSdfYmxhbmsnPkdlb0pTT048L2E+LAogICAgYW4gb3BlbiBzb3VyY2Ugc3BhdGlhbCBkYXRhIGZvcm1hdCwgYW5kIGl0IHN1cHBvcnRzIEdlb0pTT04gaW4gYWxsIHdheXMgLSBidXQgYWxzbwogICAgYWNjZXB0cyBLTUwsIEdQWCwgQ1NWLCBHVEZTLCBUb3BvSlNPTiwgYW5kIG90aGVyIGZvcm1hdHMuPC9wPgoKPHA+V2FudCB0byByZXF1ZXN0IGEgZmVhdHVyZSBvciByZXBvcnQgYSBidWc/IDxhIHRhcmdldD0nX2JsYW5rJwogICAgICAgIGhyZWY9J2h0dHBzOi8vZ2l0aHViLmNvbS9tYXBib3gvZ2VvanNvbi5pby9pc3N1ZXM/c3RhdGU9b3Blbic+T3BlbgogICAgICAgIGFuIGlzc3VlCiAgICAgICAgb24gZ2VvanNvbi5pbydzIGlzc3VlIHRyYWNrZXIuPC9hPgoKPGgzPkkndmUgZ290IGRhdGE8L2gzPgoKPHA+SWYgeW91IGhhdmUgZGF0YSwgbGlrZSBhIEtNTCwgR2VvSlNPTiwgb3IgQ1NWIGZpbGUsIGp1c3QgZHJhZyAmYW1wOyBkcm9wCiAgICBpdCBvbnRvIHRoZSBwYWdlIG9yIGNsaWNrICdPcGVuJyBhbmQgc2VsZWN0IHlvdXIgZmlsZS4gWW91ciBkYXRhIHNob3VsZCBhcHBlYXIgb24KICAgIHRoZSBtYXAhPC9wPgoKPGgzPkkgd2FudCB0byBkcmF3IGZlYXR1cmVzPC9oMz4KCjxwPlVzZSB0aGUgZHJhd2luZyB0b29scyB0byBkcmF3IHBvaW50cywgcG9seWdvbnMsCiAgICBsaW5lcyBhbmQgcmVjdGFuZ2xlcy4gQWZ0ZXIgeW91J3JlIGRvbmUgZHJhd2luZyB0aGUgc2hhcGVzLCB5b3UgY2FuIGFkZAogICAgaW5mb3JtYXRpb24gdG8gZWFjaCBmZWF0dXJlIGJ5IGNsaWNraW5nIG9uIGl0LCBlZGl0aW5nIHRoZSBmZWF0dXJlJ3MgcHJvcGVydGllcywKICAgIGFuZCBjbGlja2luZyAnU2F2ZScuPC9wPgoKPHA+UHJvcGVydGllcyBpbiBHZW9KU09OIGFyZSBzdG9yZWQgYXMgJ2tleSB2YWx1ZSBwYWlycycgLSBzbywgZm9yIGluc3RhbmNlLAogICAgaWYgeW91IHdhbnRlZCB0byBhZGQgYSBuYW1lIHRvIGVhY2ggZmVhdHVyZSwgdHlwZSAnbmFtZScgaW4gdGhlIGZpcnN0IHRhYmxlCiAgICBmaWVsZCwgYW5kIHRoZSBuYW1lIG9mIHRoZSBmZWF0dXJlIGluIHRoZSBzZWNvbmQuPC9wPgoKPGgzPkknbSBhIGNvZGVyPC9oMz4KCjxwPjxhIGhyZWY9JyNnZW9qc29uLWlvLWFwaSc+Z2VvanNvbi5pbyBhY2NlcHRzIFVSTCBwYXJhbWV0ZXJzPC9hPgogICAgdGhhdCBtYWtlIGl0IGVhc3kgdG8gZ28gZnJvbSBhIEdlb0pTT04gZmlsZSBvbiB5b3VyIGNvbXB1dGVyIHRvIGdlb2pzb24uaW8uCgo8aDM+UHJpdmFjeSAmYW1wOyBMaWNlbnNlIElzc3VlczwvaDM+Cgo8dWw+CiAgICA8bGk+PHN0cm9uZz5UaGUgZGF0YSB5b3UgY3JlYXRlIGFuZCBtb2RpZnkgaW4gZ2VvanNvbi5pbzwvc3Ryb25nPiBkb2Vzbid0CiAgICAgICAgYWNxdWlyZSBhbnkgYWRkaXRpb25hbCBsaWNlbnNlOiBpZiBpdCdzIHNlY3JldCBhbmQgY29weXJpZ2h0ZWQsIGl0IHdpbGwgcmVtYWluCiAgICAgICAgdGhhdCB3YXkgLSBpdCBkb2Vzbid0IGhhdmUgdG8gYmUgcHVibGljIG9yIG9wZW4gc291cmNlLgogICAgPC9saT4KPC91bD4=","base64") +
+    var html = Buffer("PGgyPkhlbHA8L2gyPgoKPHA+PHN0cm9uZz5nZW9qc29uLmlvPC9zdHJvbmc+IGlzIGEgcXVpY2ssIHNpbXBsZSB0b29sIGZvciBjcmVhdGluZywKICAgIHZpZXdpbmcsIGFuZCBzaGFyaW5nIG1hcHMuIGdlb2pzb24uaW8gaXMgbmFtZWQgYWZ0ZXIgPGEgaHJlZj0naHR0cDovL2dlb2pzb24ub3JnLycgdGFyZ2V0PSdfYmxhbmsnPkdlb0pTT048L2E+LAogICAgYW4gb3BlbiBzb3VyY2Ugc3BhdGlhbCBkYXRhIGZvcm1hdCwgYW5kIGl0IHN1cHBvcnRzIEdlb0pTT04gaW4gYWxsIHdheXMgLSBidXQgYWxzbwogICAgYWNjZXB0cyBLTUwsIEdQWCwgQ1NWLCBHVEZTLCBUb3BvSlNPTiwgYW5kIG90aGVyIGZvcm1hdHMuPC9wPgoKPHA+V2FudCB0byByZXF1ZXN0IGEgZmVhdHVyZSBvciByZXBvcnQgYSBidWc/IDxhIHRhcmdldD0nX2JsYW5rJwogICAgICAgIGhyZWY9J2h0dHBzOi8vZ2l0aHViLmNvbS9tYXBib3gvZ2VvanNvbi5pby9pc3N1ZXM/c3RhdGU9b3Blbic+T3BlbgogICAgICAgIGFuIGlzc3VlCiAgICAgICAgb24gZ2VvanNvbi5pbydzIGlzc3VlIHRyYWNrZXIuPC9hPgoKPGgzPkkndmUgZ290IGRhdGE8L2gzPgoKPHA+SWYgeW91IGhhdmUgZGF0YSwgbGlrZSBhIEtNTCwgR2VvSlNPTiwgb3IgQ1NWIGZpbGUsIGp1c3QgZHJhZyAmYW1wOyBkcm9wCiAgICBpdCBvbnRvIHRoZSBwYWdlIG9yIGNsaWNrICdPcGVuJyBhbmQgc2VsZWN0IHlvdXIgZmlsZS4gWW91ciBkYXRhIHNob3VsZCBhcHBlYXIgb24KICAgIHRoZSBtYXAhPC9wPgoKPGgzPkkgd2FudCB0byBkcmF3IGZlYXR1cmVzPC9oMz4KCjxwPlVzZSB0aGUgZHJhd2luZyB0b29scyB0byBkcmF3IHBvaW50cywgcG9seWdvbnMsCiAgICBsaW5lcywgcmVjdGFuZ2xlcywgYW5kIGNpcmNsZXMuIEFmdGVyIHlvdSdyZSBkb25lIGRyYXdpbmcgdGhlIHNoYXBlcywgeW91IGNhbiBhZGQKICAgIGluZm9ybWF0aW9uIHRvIGVhY2ggZmVhdHVyZSBieSBjbGlja2luZyBvbiBpdCwgZWRpdGluZyB0aGUgZmVhdHVyZSdzIHByb3BlcnRpZXMsCiAgICBhbmQgY2xpY2tpbmcgJ1NhdmUnLjwvcD4KCjxwPk5vdGU6IENpcmNsZXMgYXJlIG5vdCBzdXBwb3J0ZWQgaW4gR2VvSlNPTiwgc28gdGhlIGNpcmNsZSBkcmF3aW5nIHRvb2wgaXMgcmVhbGx5IGNyZWF0aW5nIGEgY2lyY2xlLXNoYXBlZCBwb2x5Z29uCiAgICB3aXRoIDY0IHZlcnRpY2VzLjwvcD4KCjxwPlByb3BlcnRpZXMgaW4gR2VvSlNPTiBhcmUgc3RvcmVkIGFzICdrZXkgdmFsdWUgcGFpcnMnIC0gc28sIGZvciBpbnN0YW5jZSwKICAgIGlmIHlvdSB3YW50ZWQgdG8gYWRkIGEgbmFtZSB0byBlYWNoIGZlYXR1cmUsIHR5cGUgJ25hbWUnIGluIHRoZSBmaXJzdCB0YWJsZQogICAgZmllbGQsIGFuZCB0aGUgbmFtZSBvZiB0aGUgZmVhdHVyZSBpbiB0aGUgc2Vjb25kLjwvcD4KCjxoMz5JJ20gYSBjb2RlcjwvaDM+Cgo8cD48YSBocmVmPScjZ2VvanNvbi1pby1hcGknPmdlb2pzb24uaW8gYWNjZXB0cyBVUkwgcGFyYW1ldGVyczwvYT4KICAgIHRoYXQgbWFrZSBpdCBlYXN5IHRvIGdvIGZyb20gYSBHZW9KU09OIGZpbGUgb24geW91ciBjb21wdXRlciB0byBnZW9qc29uLmlvLgoKPGgzPlByaXZhY3kgJmFtcDsgTGljZW5zZSBJc3N1ZXM8L2gzPgoKPHVsPgogICAgPGxpPjxzdHJvbmc+VGhlIGRhdGEgeW91IGNyZWF0ZSBhbmQgbW9kaWZ5IGluIGdlb2pzb24uaW88L3N0cm9uZz4gZG9lc24ndAogICAgICAgIGFjcXVpcmUgYW55IGFkZGl0aW9uYWwgbGljZW5zZTogaWYgaXQncyBzZWNyZXQgYW5kIGNvcHlyaWdodGVkLCBpdCB3aWxsIHJlbWFpbgogICAgICAgIHRoYXQgd2F5IC0gaXQgZG9lc24ndCBoYXZlIHRvIGJlIHB1YmxpYyBvciBvcGVuIHNvdXJjZS4KICAgIDwvbGk+CjwvdWw+","base64") +
         '<br><hr><br>' +
         marked("## Geojson.io API\n\nYou can interact with geojson.io programmatically via url parameters:\n\n## URL API\n\nYou can do a few interesting things with just URLs and geojson.io. Here are the\ncurrent URL formats.\n\n### `map`\n\nOpen the map at a specific location. The argument is numbers separated by `/`\nin the form `zoom/latitude/longitude`.\n\n#### Example:\n\nhttp://geojson.io/#map=2/20.0/0.0\n\n### `data=data:application/json,`\n\nOpen the map and load a chunk of [GeoJSON](http://geojson.org/) data from a\nURL segment directly onto the map. The GeoJSON data should be encoded\nas per `encodeURIComponent(JSON.stringify(geojson_data))`.\n\n#### Example:\n\nhttp://geojson.io/#data=data:application/json,%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0%2C0%5D%2C%5B10%2C10%5D%5D%7D\n\n### `data=data:text/x-url,`\n\nLoad GeoJSON data from a URL on the internet onto the map. The URL must\nrefer directly to a resource that is:\n\n- Freely accessible (not behind a password)\n- Supports [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing)\n- Is valid GeoJSON\n\nThe URL should be encoded as per `encodeURIComponent(url)`.\n\n#### Example:\n\nhttp://geojson.io/#data=data:text/x-url,http%3A%2F%2Fapi.tiles.mapbox.com%2Fv3%2Ftmcw.map-gdv4cswo%2Fmarkers.geojson\n\n### `id=gist:`\n\nLoad GeoJSON data from a [GitHub Gist](https://gist.github.com/), given an argument\nin the form of `login/gistid`. The Gist can be public or private, and must\ncontain a file with a `.geojson` extension that is valid GeoJSON.\n\n#### Example:\n\nhttp://geojson.io/#id=gist:tmcw/e9a29ad54dbaa83dee08&map=8/39.198/-76.981\n\n### `id=github:`\n\nLoad a file from a GitHub repository. You must have access to the file, and\nit must be valid GeoJSON.\n\nThe url is in the form:\n\n    login/repository/blob/branch/filepath\n\n#### Example:\n\nhttp://geojson.io/#id=github:benbalter/dc-wifi-social/blob/master/bars.geojson&map=14/38.9140/-77.0302\n");
     function render(selection) {
@@ -60194,6 +60194,9 @@ module.exports = function(context) {
       lineNumbers: true,
       foldGutter: true
     });
+
+    // blur the editor so map keybindings will work on initial load
+    editor.display.input.blur();
 
     editor.foldCode(CodeMirror.Pos(0, 0));
     editor.matchBrackets();
@@ -60603,6 +60606,7 @@ function ui(context) {
 
     var map = container
       .append('div')
+      .attr('id', 'map')
       .attr('class', 'map')
       .call(context.map)
       .call(layer_switch(context))
@@ -62191,6 +62195,7 @@ const drawStyles = require('../draw/styles');
 
 let writable = false;
 let drawing = false;
+let editing = false;
 
 const dummyGeojson = {
   type: 'FeatureCollection',
@@ -62210,6 +62215,39 @@ const LIGHT_FEATURE_COLOR = '#e8e8e8';
 
 module.exports = function (context, readonly) {
   writable = !readonly;
+
+  // keyboard shortcuts
+  const keybinding = d3.keybinding('map')
+  // delete key triggers draw.trash()
+    .on('⌫', () => {
+      if (editing) {
+        context.Draw.trash();
+      }
+    })
+    .on('m', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_point');
+      }
+    })
+    .on('l', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_line_string');
+      }
+    }).on('p', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_polygon');
+      }
+    }).on('r', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_rectangle');
+      }
+    }).on('c', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_circle');
+      }
+    });
+
+  d3.select(document).call(keybinding);
 
   function maybeShowEditControl() {
     // if there are features, show the edit button
@@ -62247,6 +62285,7 @@ module.exports = function (context, readonly) {
       );
 
       context.Draw = new MapboxDraw({
+
         displayControlsDefault: false,
         modes: {
           ...MapboxDraw.modes,
@@ -62268,7 +62307,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_point');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_point'],
-            title: 'Draw Point'
+            title: 'Draw Point (m)'
           },
           {
             on: 'click',
@@ -62277,7 +62316,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_line_string');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_line'],
-            title: 'Draw LineString'
+            title: 'Draw LineString (l)'
           },
           {
             on: 'click',
@@ -62286,7 +62325,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_polygon');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_polygon'],
-            title: 'Draw Polygon'
+            title: 'Draw Polygon (p)'
           },
           {
             on: 'click',
@@ -62298,7 +62337,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_rectangle',
             ],
-            title: 'Draw Rectangular Polygon'
+            title: 'Draw Rectangular Polygon (r)'
           },
           {
             on: 'click',
@@ -62310,7 +62349,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_circle',
             ],
-            title: 'Draw Circular Polygon'
+            title: 'Draw Circular Polygon (c)'
           },
         ],
       });
@@ -62331,6 +62370,7 @@ module.exports = function (context, readonly) {
       context.map.addControl(trashControl, 'top-right');
 
       const exitEditMode = () => {
+        editing = false;
         // show the data layers
         context.map.setLayoutProperty('map-data-fill', 'visibility', 'visible');
         context.map.setLayoutProperty(
@@ -62386,6 +62426,7 @@ module.exports = function (context, readonly) {
 
       // enter edit mode
       d3.selectAll('.mapbox-gl-draw_edit').on('click', function () {
+        editing = true;
         // hide the edit button and draw tools
         d3.select('.edit-control').style('display', 'none');
         d3.select('.mapboxgl-ctrl-group:nth-child(3)').style('display', 'none');

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -60030,7 +60030,7 @@ function geojsonIO() {
 var marked = require('marked');
 
 module.exports = function(context) {
-    var html = Buffer("PGgyPkhlbHA8L2gyPgoKPHA+PHN0cm9uZz5nZW9qc29uLmlvPC9zdHJvbmc+IGlzIGEgcXVpY2ssIHNpbXBsZSB0b29sIGZvciBjcmVhdGluZywKICAgIHZpZXdpbmcsIGFuZCBzaGFyaW5nIG1hcHMuIGdlb2pzb24uaW8gaXMgbmFtZWQgYWZ0ZXIgPGEgaHJlZj0naHR0cDovL2dlb2pzb24ub3JnLycgdGFyZ2V0PSdfYmxhbmsnPkdlb0pTT048L2E+LAogICAgYW4gb3BlbiBzb3VyY2Ugc3BhdGlhbCBkYXRhIGZvcm1hdCwgYW5kIGl0IHN1cHBvcnRzIEdlb0pTT04gaW4gYWxsIHdheXMgLSBidXQgYWxzbwogICAgYWNjZXB0cyBLTUwsIEdQWCwgQ1NWLCBHVEZTLCBUb3BvSlNPTiwgYW5kIG90aGVyIGZvcm1hdHMuPC9wPgoKPHA+V2FudCB0byByZXF1ZXN0IGEgZmVhdHVyZSBvciByZXBvcnQgYSBidWc/IDxhIHRhcmdldD0nX2JsYW5rJwogICAgICAgIGhyZWY9J2h0dHBzOi8vZ2l0aHViLmNvbS9tYXBib3gvZ2VvanNvbi5pby9pc3N1ZXM/c3RhdGU9b3Blbic+T3BlbgogICAgICAgIGFuIGlzc3VlCiAgICAgICAgb24gZ2VvanNvbi5pbydzIGlzc3VlIHRyYWNrZXIuPC9hPgoKPGgzPkkndmUgZ290IGRhdGE8L2gzPgoKPHA+SWYgeW91IGhhdmUgZGF0YSwgbGlrZSBhIEtNTCwgR2VvSlNPTiwgb3IgQ1NWIGZpbGUsIGp1c3QgZHJhZyAmYW1wOyBkcm9wCiAgICBpdCBvbnRvIHRoZSBwYWdlIG9yIGNsaWNrICdPcGVuJyBhbmQgc2VsZWN0IHlvdXIgZmlsZS4gWW91ciBkYXRhIHNob3VsZCBhcHBlYXIgb24KICAgIHRoZSBtYXAhPC9wPgoKPGgzPkkgd2FudCB0byBkcmF3IGZlYXR1cmVzPC9oMz4KCjxwPlVzZSB0aGUgZHJhd2luZyB0b29scyB0byBkcmF3IHBvaW50cywgcG9seWdvbnMsCiAgICBsaW5lcyBhbmQgcmVjdGFuZ2xlcy4gQWZ0ZXIgeW91J3JlIGRvbmUgZHJhd2luZyB0aGUgc2hhcGVzLCB5b3UgY2FuIGFkZAogICAgaW5mb3JtYXRpb24gdG8gZWFjaCBmZWF0dXJlIGJ5IGNsaWNraW5nIG9uIGl0LCBlZGl0aW5nIHRoZSBmZWF0dXJlJ3MgcHJvcGVydGllcywKICAgIGFuZCBjbGlja2luZyAnU2F2ZScuPC9wPgoKPHA+UHJvcGVydGllcyBpbiBHZW9KU09OIGFyZSBzdG9yZWQgYXMgJ2tleSB2YWx1ZSBwYWlycycgLSBzbywgZm9yIGluc3RhbmNlLAogICAgaWYgeW91IHdhbnRlZCB0byBhZGQgYSBuYW1lIHRvIGVhY2ggZmVhdHVyZSwgdHlwZSAnbmFtZScgaW4gdGhlIGZpcnN0IHRhYmxlCiAgICBmaWVsZCwgYW5kIHRoZSBuYW1lIG9mIHRoZSBmZWF0dXJlIGluIHRoZSBzZWNvbmQuPC9wPgoKPGgzPkknbSBhIGNvZGVyPC9oMz4KCjxwPjxhIGhyZWY9JyNnZW9qc29uLWlvLWFwaSc+Z2VvanNvbi5pbyBhY2NlcHRzIFVSTCBwYXJhbWV0ZXJzPC9hPgogICAgdGhhdCBtYWtlIGl0IGVhc3kgdG8gZ28gZnJvbSBhIEdlb0pTT04gZmlsZSBvbiB5b3VyIGNvbXB1dGVyIHRvIGdlb2pzb24uaW8uCgo8aDM+UHJpdmFjeSAmYW1wOyBMaWNlbnNlIElzc3VlczwvaDM+Cgo8dWw+CiAgICA8bGk+PHN0cm9uZz5UaGUgZGF0YSB5b3UgY3JlYXRlIGFuZCBtb2RpZnkgaW4gZ2VvanNvbi5pbzwvc3Ryb25nPiBkb2Vzbid0CiAgICAgICAgYWNxdWlyZSBhbnkgYWRkaXRpb25hbCBsaWNlbnNlOiBpZiBpdCdzIHNlY3JldCBhbmQgY29weXJpZ2h0ZWQsIGl0IHdpbGwgcmVtYWluCiAgICAgICAgdGhhdCB3YXkgLSBpdCBkb2Vzbid0IGhhdmUgdG8gYmUgcHVibGljIG9yIG9wZW4gc291cmNlLgogICAgPC9saT4KPC91bD4=","base64") +
+    var html = Buffer("PGgyPkhlbHA8L2gyPgoKPHA+PHN0cm9uZz5nZW9qc29uLmlvPC9zdHJvbmc+IGlzIGEgcXVpY2ssIHNpbXBsZSB0b29sIGZvciBjcmVhdGluZywKICAgIHZpZXdpbmcsIGFuZCBzaGFyaW5nIG1hcHMuIGdlb2pzb24uaW8gaXMgbmFtZWQgYWZ0ZXIgPGEgaHJlZj0naHR0cDovL2dlb2pzb24ub3JnLycgdGFyZ2V0PSdfYmxhbmsnPkdlb0pTT048L2E+LAogICAgYW4gb3BlbiBzb3VyY2Ugc3BhdGlhbCBkYXRhIGZvcm1hdCwgYW5kIGl0IHN1cHBvcnRzIEdlb0pTT04gaW4gYWxsIHdheXMgLSBidXQgYWxzbwogICAgYWNjZXB0cyBLTUwsIEdQWCwgQ1NWLCBHVEZTLCBUb3BvSlNPTiwgYW5kIG90aGVyIGZvcm1hdHMuPC9wPgoKPHA+V2FudCB0byByZXF1ZXN0IGEgZmVhdHVyZSBvciByZXBvcnQgYSBidWc/IDxhIHRhcmdldD0nX2JsYW5rJwogICAgICAgIGhyZWY9J2h0dHBzOi8vZ2l0aHViLmNvbS9tYXBib3gvZ2VvanNvbi5pby9pc3N1ZXM/c3RhdGU9b3Blbic+T3BlbgogICAgICAgIGFuIGlzc3VlCiAgICAgICAgb24gZ2VvanNvbi5pbydzIGlzc3VlIHRyYWNrZXIuPC9hPgoKPGgzPkkndmUgZ290IGRhdGE8L2gzPgoKPHA+SWYgeW91IGhhdmUgZGF0YSwgbGlrZSBhIEtNTCwgR2VvSlNPTiwgb3IgQ1NWIGZpbGUsIGp1c3QgZHJhZyAmYW1wOyBkcm9wCiAgICBpdCBvbnRvIHRoZSBwYWdlIG9yIGNsaWNrICdPcGVuJyBhbmQgc2VsZWN0IHlvdXIgZmlsZS4gWW91ciBkYXRhIHNob3VsZCBhcHBlYXIgb24KICAgIHRoZSBtYXAhPC9wPgoKPGgzPkkgd2FudCB0byBkcmF3IGZlYXR1cmVzPC9oMz4KCjxwPlVzZSB0aGUgZHJhd2luZyB0b29scyB0byBkcmF3IHBvaW50cywgcG9seWdvbnMsCiAgICBsaW5lcywgcmVjdGFuZ2xlcywgYW5kIGNpcmNsZXMuIEFmdGVyIHlvdSdyZSBkb25lIGRyYXdpbmcgdGhlIHNoYXBlcywgeW91IGNhbiBhZGQKICAgIGluZm9ybWF0aW9uIHRvIGVhY2ggZmVhdHVyZSBieSBjbGlja2luZyBvbiBpdCwgZWRpdGluZyB0aGUgZmVhdHVyZSdzIHByb3BlcnRpZXMsCiAgICBhbmQgY2xpY2tpbmcgJ1NhdmUnLjwvcD4KCjxwPk5vdGU6IENpcmNsZXMgYXJlIG5vdCBzdXBwb3J0ZWQgaW4gR2VvSlNPTiwgc28gdGhlIGNpcmNsZSBkcmF3aW5nIHRvb2wgaXMgcmVhbGx5IGNyZWF0aW5nIGEgY2lyY2xlLXNoYXBlZCBwb2x5Z29uCiAgICB3aXRoIDY0IHZlcnRpY2VzLjwvcD4KCjxwPlByb3BlcnRpZXMgaW4gR2VvSlNPTiBhcmUgc3RvcmVkIGFzICdrZXkgdmFsdWUgcGFpcnMnIC0gc28sIGZvciBpbnN0YW5jZSwKICAgIGlmIHlvdSB3YW50ZWQgdG8gYWRkIGEgbmFtZSB0byBlYWNoIGZlYXR1cmUsIHR5cGUgJ25hbWUnIGluIHRoZSBmaXJzdCB0YWJsZQogICAgZmllbGQsIGFuZCB0aGUgbmFtZSBvZiB0aGUgZmVhdHVyZSBpbiB0aGUgc2Vjb25kLjwvcD4KCjxoMz5JJ20gYSBjb2RlcjwvaDM+Cgo8cD48YSBocmVmPScjZ2VvanNvbi1pby1hcGknPmdlb2pzb24uaW8gYWNjZXB0cyBVUkwgcGFyYW1ldGVyczwvYT4KICAgIHRoYXQgbWFrZSBpdCBlYXN5IHRvIGdvIGZyb20gYSBHZW9KU09OIGZpbGUgb24geW91ciBjb21wdXRlciB0byBnZW9qc29uLmlvLgoKPGgzPlByaXZhY3kgJmFtcDsgTGljZW5zZSBJc3N1ZXM8L2gzPgoKPHVsPgogICAgPGxpPjxzdHJvbmc+VGhlIGRhdGEgeW91IGNyZWF0ZSBhbmQgbW9kaWZ5IGluIGdlb2pzb24uaW88L3N0cm9uZz4gZG9lc24ndAogICAgICAgIGFjcXVpcmUgYW55IGFkZGl0aW9uYWwgbGljZW5zZTogaWYgaXQncyBzZWNyZXQgYW5kIGNvcHlyaWdodGVkLCBpdCB3aWxsIHJlbWFpbgogICAgICAgIHRoYXQgd2F5IC0gaXQgZG9lc24ndCBoYXZlIHRvIGJlIHB1YmxpYyBvciBvcGVuIHNvdXJjZS4KICAgIDwvbGk+CjwvdWw+","base64") +
         '<br><hr><br>' +
         marked("## Geojson.io API\n\nYou can interact with geojson.io programmatically via url parameters:\n\n## URL API\n\nYou can do a few interesting things with just URLs and geojson.io. Here are the\ncurrent URL formats.\n\n### `map`\n\nOpen the map at a specific location. The argument is numbers separated by `/`\nin the form `zoom/latitude/longitude`.\n\n#### Example:\n\nhttp://geojson.io/#map=2/20.0/0.0\n\n### `data=data:application/json,`\n\nOpen the map and load a chunk of [GeoJSON](http://geojson.org/) data from a\nURL segment directly onto the map. The GeoJSON data should be encoded\nas per `encodeURIComponent(JSON.stringify(geojson_data))`.\n\n#### Example:\n\nhttp://geojson.io/#data=data:application/json,%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0%2C0%5D%2C%5B10%2C10%5D%5D%7D\n\n### `data=data:text/x-url,`\n\nLoad GeoJSON data from a URL on the internet onto the map. The URL must\nrefer directly to a resource that is:\n\n- Freely accessible (not behind a password)\n- Supports [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing)\n- Is valid GeoJSON\n\nThe URL should be encoded as per `encodeURIComponent(url)`.\n\n#### Example:\n\nhttp://geojson.io/#data=data:text/x-url,http%3A%2F%2Fapi.tiles.mapbox.com%2Fv3%2Ftmcw.map-gdv4cswo%2Fmarkers.geojson\n\n### `id=gist:`\n\nLoad GeoJSON data from a [GitHub Gist](https://gist.github.com/), given an argument\nin the form of `login/gistid`. The Gist can be public or private, and must\ncontain a file with a `.geojson` extension that is valid GeoJSON.\n\n#### Example:\n\nhttp://geojson.io/#id=gist:tmcw/e9a29ad54dbaa83dee08&map=8/39.198/-76.981\n\n### `id=github:`\n\nLoad a file from a GitHub repository. You must have access to the file, and\nit must be valid GeoJSON.\n\nThe url is in the form:\n\n    login/repository/blob/branch/filepath\n\n#### Example:\n\nhttp://geojson.io/#id=github:benbalter/dc-wifi-social/blob/master/bars.geojson&map=14/38.9140/-77.0302\n");
     function render(selection) {
@@ -60149,6 +60149,9 @@ module.exports = function(context) {
       lineNumbers: true,
       foldGutter: true
     });
+
+    // blur the editor so map keybindings will work on initial load
+    editor.display.input.blur();
 
     editor.foldCode(CodeMirror.Pos(0, 0));
     editor.matchBrackets();
@@ -60558,6 +60561,7 @@ function ui(context) {
 
     var map = container
       .append('div')
+      .attr('id', 'map')
       .attr('class', 'map')
       .call(context.map)
       .call(layer_switch(context))
@@ -62146,6 +62150,7 @@ const drawStyles = require('../draw/styles');
 
 let writable = false;
 let drawing = false;
+let editing = false;
 
 const dummyGeojson = {
   type: 'FeatureCollection',
@@ -62165,6 +62170,39 @@ const LIGHT_FEATURE_COLOR = '#e8e8e8';
 
 module.exports = function (context, readonly) {
   writable = !readonly;
+
+  // keyboard shortcuts
+  const keybinding = d3.keybinding('map')
+  // delete key triggers draw.trash()
+    .on('⌫', () => {
+      if (editing) {
+        context.Draw.trash();
+      }
+    })
+    .on('m', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_point');
+      }
+    })
+    .on('l', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_line_string');
+      }
+    }).on('p', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_polygon');
+      }
+    }).on('r', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_rectangle');
+      }
+    }).on('c', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_circle');
+      }
+    });
+
+  d3.select(document).call(keybinding);
 
   function maybeShowEditControl() {
     // if there are features, show the edit button
@@ -62202,6 +62240,7 @@ module.exports = function (context, readonly) {
       );
 
       context.Draw = new MapboxDraw({
+
         displayControlsDefault: false,
         modes: {
           ...MapboxDraw.modes,
@@ -62223,7 +62262,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_point');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_point'],
-            title: 'Draw Point'
+            title: 'Draw Point (m)'
           },
           {
             on: 'click',
@@ -62232,7 +62271,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_line_string');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_line'],
-            title: 'Draw LineString'
+            title: 'Draw LineString (l)'
           },
           {
             on: 'click',
@@ -62241,7 +62280,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_polygon');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_polygon'],
-            title: 'Draw Polygon'
+            title: 'Draw Polygon (p)'
           },
           {
             on: 'click',
@@ -62253,7 +62292,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_rectangle',
             ],
-            title: 'Draw Rectangular Polygon'
+            title: 'Draw Rectangular Polygon (r)'
           },
           {
             on: 'click',
@@ -62265,7 +62304,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_circle',
             ],
-            title: 'Draw Circular Polygon'
+            title: 'Draw Circular Polygon (c)'
           },
         ],
       });
@@ -62286,6 +62325,7 @@ module.exports = function (context, readonly) {
       context.map.addControl(trashControl, 'top-right');
 
       const exitEditMode = () => {
+        editing = false;
         // show the data layers
         context.map.setLayoutProperty('map-data-fill', 'visibility', 'visible');
         context.map.setLayoutProperty(
@@ -62341,6 +62381,7 @@ module.exports = function (context, readonly) {
 
       // enter edit mode
       d3.selectAll('.mapbox-gl-draw_edit').on('click', function () {
+        editing = true;
         // hide the edit button and draw tools
         d3.select('.edit-control').style('display', 'none');
         d3.select('.mapboxgl-ctrl-group:nth-child(3)').style('display', 'none');

--- a/src/panel/json.js
+++ b/src/panel/json.js
@@ -99,6 +99,9 @@ module.exports = function(context) {
       foldGutter: true
     });
 
+    // blur the editor so map keybindings will work on initial load
+    editor.display.input.blur();
+
     editor.foldCode(CodeMirror.Pos(0, 0));
     editor.matchBrackets();
 

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -13,6 +13,7 @@ const drawStyles = require('../draw/styles');
 
 let writable = false;
 let drawing = false;
+let editing = false;
 
 const dummyGeojson = {
   type: 'FeatureCollection',
@@ -32,6 +33,39 @@ const LIGHT_FEATURE_COLOR = '#e8e8e8';
 
 module.exports = function (context, readonly) {
   writable = !readonly;
+
+  // keyboard shortcuts
+  const keybinding = d3.keybinding('map')
+  // delete key triggers draw.trash()
+    .on('⌫', () => {
+      if (editing) {
+        context.Draw.trash();
+      }
+    })
+    .on('m', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_point');
+      }
+    })
+    .on('l', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_line_string');
+      }
+    }).on('p', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_polygon');
+      }
+    }).on('r', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_rectangle');
+      }
+    }).on('c', () => {
+      if (!editing) {
+        context.Draw.changeMode('draw_circle');
+      }
+    });
+
+  d3.select(document).call(keybinding);
 
   function maybeShowEditControl() {
     // if there are features, show the edit button
@@ -69,6 +103,7 @@ module.exports = function (context, readonly) {
       );
 
       context.Draw = new MapboxDraw({
+
         displayControlsDefault: false,
         modes: {
           ...MapboxDraw.modes,
@@ -90,7 +125,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_point');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_point'],
-            title: 'Draw Point'
+            title: 'Draw Point (m)'
           },
           {
             on: 'click',
@@ -99,7 +134,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_line_string');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_line'],
-            title: 'Draw LineString'
+            title: 'Draw LineString (l)'
           },
           {
             on: 'click',
@@ -108,7 +143,7 @@ module.exports = function (context, readonly) {
               context.Draw.changeMode('draw_polygon');
             },
             classes: ['mapbox-gl-draw_ctrl-draw-btn', 'mapbox-gl-draw_polygon'],
-            title: 'Draw Polygon'
+            title: 'Draw Polygon (p)'
           },
           {
             on: 'click',
@@ -120,7 +155,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_rectangle',
             ],
-            title: 'Draw Rectangular Polygon'
+            title: 'Draw Rectangular Polygon (r)'
           },
           {
             on: 'click',
@@ -132,7 +167,7 @@ module.exports = function (context, readonly) {
               'mapbox-gl-draw_ctrl-draw-btn',
               'mapbox-gl-draw_circle',
             ],
-            title: 'Draw Circular Polygon'
+            title: 'Draw Circular Polygon (c)'
           },
         ],
       });
@@ -153,6 +188,7 @@ module.exports = function (context, readonly) {
       context.map.addControl(trashControl, 'top-right');
 
       const exitEditMode = () => {
+        editing = false;
         // show the data layers
         context.map.setLayoutProperty('map-data-fill', 'visibility', 'visible');
         context.map.setLayoutProperty(
@@ -208,6 +244,7 @@ module.exports = function (context, readonly) {
 
       // enter edit mode
       d3.selectAll('.mapbox-gl-draw_edit').on('click', function () {
+        editing = true;
         // hide the edit button and draw tools
         d3.select('.edit-control').style('display', 'none');
         d3.select('.mapboxgl-ctrl-group:nth-child(3)').style('display', 'none');


### PR DESCRIPTION
Adds keybindings:

- When editing `delete` will trigger `draw.trash()`, removing a selected feature or vertex
- When not editing, 
- - `m` will change the draw mode to `draw_point`
- - `l` will change the draw mode to `draw_line_string`
- - `p` will change the draw mode to `draw_polygon`
- - `r` will change the draw mode to `draw_rectangle`
- - `c` will change the draw mode to `draw_rectangle`

Also fixes site.css where some merge conflict markers were accidentally committed.