### PR TITLE
restore simplestyle ui in popups, handle marker-size style property

### DIFF
--- a/css/marker.css
+++ b/css/marker.css
@@ -101,11 +101,11 @@ datalist {
     display: block;
 }
 
-.add-row-button {
+.add-row-button, .add-simplestyle-properties-button {
     color: #2980b9;
 }
 
-.add-row-button:hover {
+.add-row-button:hover, .add-simplestyle-properties-button:hover {
     cursor: pointer;
     color: #199CF4;
 }

--- a/dist/site.js
+++ b/dist/site.js
@@ -59738,9 +59738,11 @@ module.exports = function (context) {
 
     sel.selectAll('.cancel').on('click', clickClose);
 
-    sel.selectAll('.save').on('click', saveFeature);
+    sel.selectAll('form').on('submit', saveFeature);
 
     sel.selectAll('.add').on('click', addRow);
+
+    sel.selectAll('.add-simplestyle-properties-button').on('click', addSimplestyleProperties);
 
     sel.selectAll('.delete-invert').on('click', removeFeature);
 
@@ -59790,6 +59792,65 @@ module.exports = function (context) {
       tr.append('th').append('input').attr('type', 'text');
 
       tr.append('td').append('input').attr('type', 'text');
+    }
+
+    function addSimplestyleProperties() {
+      // hide the button
+      sel.selectAll('.add-simplestyle-properties-button').style('display', 'none');
+
+      const data = context.data.get('map');
+      const feature = data.features[id];
+      const { properties, geometry } = feature;
+
+      if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
+
+        if (!('marker-color' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-color');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#7E7E7E');
+        }
+
+        if (!('marker-size' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-size');
+          let td = tr.append('td');
+          td.append('input').attr('type', 'text').attr('value', 'medium').attr('list', 'marker-size');
+          let datalist = td.append('datalist').attr('id', 'marker-size');
+          datalist.append('option').attr('value', 'small');
+          datalist.append('option').attr('value', 'medium');
+          datalist.append('option').attr('value', 'large');
+        }
+     
+      }
+      if (geometry.type === 'LineString' || geometry.type === 'MultiLineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('stroke' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('stroke-width' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-width');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('step', '0.1').attr('value', '2');
+        }
+        if (!('stroke-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '1');
+        }
+      }
+      if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('fill' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('fill-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '0.5');
+        }
+      }
     }
   };
 };
@@ -60606,7 +60667,6 @@ function ui(context) {
 
     var map = container
       .append('div')
-      .attr('id', 'map')
       .attr('class', 'map')
       .call(context.map)
       .call(layer_switch(context))
@@ -62728,8 +62788,22 @@ const addMarkers = (geojson, context, writable) => {
 
   
   pointFeatures.map((d, i) => {
+    const color = d.properties['marker-color'] || '#7e7e7e';
+    let scale = 1;
+
+    if (d.properties['marker-size']) {
+      if (d.properties['marker-size'] === 'small') {
+        scale = 0.6;
+      } 
+
+      if (d.properties['marker-size'] === 'large') {
+        scale = 1.2;
+      }
+    }
+
     const marker = new ClickableMarker({
-      color: d.properties['marker-color'] || '#7e7e7e',
+      color,
+      scale 
     })
       .setLngLat(d.geometry.coordinates)
       .onClick(() => {
@@ -62777,9 +62851,26 @@ function bindPopup(e, context, writable) {
   if (!properties) return;
   
   if (!Object.keys(properties).length) properties = { '': '' };
-  
+
   for (var key in properties) {
-    table +=
+    if ((key == 'marker-color' || key == 'stroke' || key == 'fill') && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="color" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else if (key == 'marker-size' && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="text" list="marker-size" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+    }
+    else if (key == 'stroke-width' && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="number" min="0" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else if ((key == 'stroke-opacity' || key == 'fill-opacity') && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="number" min="0" max="1" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else {
+      table +=
         '<tr><th><input type="text" value="' +
         key +
         '"' +
@@ -62790,6 +62881,7 @@ function bindPopup(e, context, writable) {
         '"' +
         (!writable ? ' readonly' : '') +
         ' /></td></tr>';
+    }
   }
   
   if (feature && feature.geometry) {
@@ -62840,6 +62932,34 @@ function bindPopup(e, context, writable) {
     }
     info += '</table>';
   }
+
+  // don't show the add simplestyle properties button if the feature already contains simplestyle properties
+  let showAddStyleButton = true;
+  
+  if (feature.geometry.type === 'Point' || feature.geometry.type === 'MultiPoint') {
+    if (('marker-color' in properties) && ('marker-size' in properties)) {
+      showAddStyleButton = false;
+    }
+  }
+
+  if (feature.geometry.type === 'LineString' || feature.geometry.type === 'MultiLineString') {
+    if (('stroke' in properties) && ('stroke-width' in properties) && ('stroke-opacity' in properties)) {
+      showAddStyleButton = false;
+    }
+  }
+
+  if (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') {
+    showAddStyleButton = true;
+    if (
+      ('stroke' in properties) &&
+      ('stroke-width' in properties) &&
+      ('stroke-opacity' in properties) &&
+      ('fill' in properties) &&
+      ('fill-opacity' in properties)
+    ) {
+      showAddStyleButton = false;
+    }
+  }
   
   var tabs =
       '<div class="pad1 tabs-ui clearfix col12">' +
@@ -62851,8 +62971,9 @@ function bindPopup(e, context, writable) {
       table +
       '</table>' +
       (writable
-        ? '<div class="add-row-button add fl col6"><span class="fa-solid fa-plus"></span> Add row</div>'
-        : '') +
+        ? '<div class="add-row-button add fl col4"><span class="fa-solid fa-plus"></span> Add row</div>' : '') +
+        (writable && showAddStyleButton
+          ? '<div class="add-simplestyle-properties-button fl text-right col8">Add simplestyle properties</div>' : '') +
       '</div>' +
       '</div>' +
       '<div class="space-bottom2 tab col12">' +
@@ -62867,15 +62988,17 @@ function bindPopup(e, context, writable) {
       '</div>';
   
   var content =
+      '<form action="javascript:void(0);">' +
       tabs +
       (writable
         ? '<div class="clearfix col12 pad1 keyline-top">' +
           '<div class="pill col6">' +
-          '<button class="save col6 major">Save</button> ' +
+          '<button class="save col6 major" type="submit">Save</button>' +
           '<button class="minor col6 cancel">Cancel</button>' +
           '</div>' +
           '<button class="col6 text-right pad0 delete-invert"><span class="fa-solid fa-trash"></span> Delete feature</button></div>'
-        : '');
+        : '') + 
+      '</form>';
   
   new mapboxgl.Popup({
     closeButton: false,

--- a/dist/site.mobile.js
+++ b/dist/site.mobile.js
@@ -59663,9 +59663,11 @@ module.exports = function (context) {
 
     sel.selectAll('.cancel').on('click', clickClose);
 
-    sel.selectAll('.save').on('click', saveFeature);
+    sel.selectAll('form').on('submit', saveFeature);
 
     sel.selectAll('.add').on('click', addRow);
+
+    sel.selectAll('.add-simplestyle-properties-button').on('click', addSimplestyleProperties);
 
     sel.selectAll('.delete-invert').on('click', removeFeature);
 
@@ -59715,6 +59717,65 @@ module.exports = function (context) {
       tr.append('th').append('input').attr('type', 'text');
 
       tr.append('td').append('input').attr('type', 'text');
+    }
+
+    function addSimplestyleProperties() {
+      // hide the button
+      sel.selectAll('.add-simplestyle-properties-button').style('display', 'none');
+
+      const data = context.data.get('map');
+      const feature = data.features[id];
+      const { properties, geometry } = feature;
+
+      if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
+
+        if (!('marker-color' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-color');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#7E7E7E');
+        }
+
+        if (!('marker-size' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-size');
+          let td = tr.append('td');
+          td.append('input').attr('type', 'text').attr('value', 'medium').attr('list', 'marker-size');
+          let datalist = td.append('datalist').attr('id', 'marker-size');
+          datalist.append('option').attr('value', 'small');
+          datalist.append('option').attr('value', 'medium');
+          datalist.append('option').attr('value', 'large');
+        }
+     
+      }
+      if (geometry.type === 'LineString' || geometry.type === 'MultiLineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('stroke' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('stroke-width' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-width');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('step', '0.1').attr('value', '2');
+        }
+        if (!('stroke-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '1');
+        }
+      }
+      if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('fill' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('fill-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '0.5');
+        }
+      }
     }
   };
 };
@@ -60561,7 +60622,6 @@ function ui(context) {
 
     var map = container
       .append('div')
-      .attr('id', 'map')
       .attr('class', 'map')
       .call(context.map)
       .call(layer_switch(context))
@@ -62683,8 +62743,22 @@ const addMarkers = (geojson, context, writable) => {
 
   
   pointFeatures.map((d, i) => {
+    const color = d.properties['marker-color'] || '#7e7e7e';
+    let scale = 1;
+
+    if (d.properties['marker-size']) {
+      if (d.properties['marker-size'] === 'small') {
+        scale = 0.6;
+      } 
+
+      if (d.properties['marker-size'] === 'large') {
+        scale = 1.2;
+      }
+    }
+
     const marker = new ClickableMarker({
-      color: d.properties['marker-color'] || '#7e7e7e',
+      color,
+      scale 
     })
       .setLngLat(d.geometry.coordinates)
       .onClick(() => {
@@ -62732,9 +62806,26 @@ function bindPopup(e, context, writable) {
   if (!properties) return;
   
   if (!Object.keys(properties).length) properties = { '': '' };
-  
+
   for (var key in properties) {
-    table +=
+    if ((key == 'marker-color' || key == 'stroke' || key == 'fill') && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="color" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else if (key == 'marker-size' && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="text" list="marker-size" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /><datalist id="marker-size"><option value="small"><option value="medium"><option value="large"></datalist></td></tr>';
+    }
+    else if (key == 'stroke-width' && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="number" min="0" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else if ((key == 'stroke-opacity' || key == 'fill-opacity') && writable) {
+      table += '<tr class="style-row"><th><input type="text" value="' + key + '"' + (!writable ? ' readonly' : '') + ' /></th>' +
+          '<td><input type="number" min="0" max="1" step="0.1" value="' + properties[key] + '"' + (!writable ? ' readonly' : '') + ' /></td></tr>';
+    }
+    else {
+      table +=
         '<tr><th><input type="text" value="' +
         key +
         '"' +
@@ -62745,6 +62836,7 @@ function bindPopup(e, context, writable) {
         '"' +
         (!writable ? ' readonly' : '') +
         ' /></td></tr>';
+    }
   }
   
   if (feature && feature.geometry) {
@@ -62795,6 +62887,34 @@ function bindPopup(e, context, writable) {
     }
     info += '</table>';
   }
+
+  // don't show the add simplestyle properties button if the feature already contains simplestyle properties
+  let showAddStyleButton = true;
+  
+  if (feature.geometry.type === 'Point' || feature.geometry.type === 'MultiPoint') {
+    if (('marker-color' in properties) && ('marker-size' in properties)) {
+      showAddStyleButton = false;
+    }
+  }
+
+  if (feature.geometry.type === 'LineString' || feature.geometry.type === 'MultiLineString') {
+    if (('stroke' in properties) && ('stroke-width' in properties) && ('stroke-opacity' in properties)) {
+      showAddStyleButton = false;
+    }
+  }
+
+  if (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') {
+    showAddStyleButton = true;
+    if (
+      ('stroke' in properties) &&
+      ('stroke-width' in properties) &&
+      ('stroke-opacity' in properties) &&
+      ('fill' in properties) &&
+      ('fill-opacity' in properties)
+    ) {
+      showAddStyleButton = false;
+    }
+  }
   
   var tabs =
       '<div class="pad1 tabs-ui clearfix col12">' +
@@ -62806,8 +62926,9 @@ function bindPopup(e, context, writable) {
       table +
       '</table>' +
       (writable
-        ? '<div class="add-row-button add fl col6"><span class="fa-solid fa-plus"></span> Add row</div>'
-        : '') +
+        ? '<div class="add-row-button add fl col4"><span class="fa-solid fa-plus"></span> Add row</div>' : '') +
+        (writable && showAddStyleButton
+          ? '<div class="add-simplestyle-properties-button fl text-right col8">Add simplestyle properties</div>' : '') +
       '</div>' +
       '</div>' +
       '<div class="space-bottom2 tab col12">' +
@@ -62822,15 +62943,17 @@ function bindPopup(e, context, writable) {
       '</div>';
   
   var content =
+      '<form action="javascript:void(0);">' +
       tabs +
       (writable
         ? '<div class="clearfix col12 pad1 keyline-top">' +
           '<div class="pill col6">' +
-          '<button class="save col6 major">Save</button> ' +
+          '<button class="save col6 major" type="submit">Save</button>' +
           '<button class="minor col6 cancel">Cancel</button>' +
           '</div>' +
           '<button class="col6 text-right pad0 delete-invert"><span class="fa-solid fa-trash"></span> Delete feature</button></div>'
-        : '');
+        : '') + 
+      '</form>';
   
   new mapboxgl.Popup({
     closeButton: false,

--- a/src/lib/popup.js
+++ b/src/lib/popup.js
@@ -4,9 +4,11 @@ module.exports = function (context) {
 
     sel.selectAll('.cancel').on('click', clickClose);
 
-    sel.selectAll('.save').on('click', saveFeature);
+    sel.selectAll('form').on('submit', saveFeature);
 
     sel.selectAll('.add').on('click', addRow);
+
+    sel.selectAll('.add-simplestyle-properties-button').on('click', addSimplestyleProperties);
 
     sel.selectAll('.delete-invert').on('click', removeFeature);
 
@@ -56,6 +58,65 @@ module.exports = function (context) {
       tr.append('th').append('input').attr('type', 'text');
 
       tr.append('td').append('input').attr('type', 'text');
+    }
+
+    function addSimplestyleProperties() {
+      // hide the button
+      sel.selectAll('.add-simplestyle-properties-button').style('display', 'none');
+
+      const data = context.data.get('map');
+      const feature = data.features[id];
+      const { properties, geometry } = feature;
+
+      if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
+
+        if (!('marker-color' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-color');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#7E7E7E');
+        }
+
+        if (!('marker-size' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'marker-size');
+          let td = tr.append('td');
+          td.append('input').attr('type', 'text').attr('value', 'medium').attr('list', 'marker-size');
+          let datalist = td.append('datalist').attr('id', 'marker-size');
+          datalist.append('option').attr('value', 'small');
+          datalist.append('option').attr('value', 'medium');
+          datalist.append('option').attr('value', 'large');
+        }
+     
+      }
+      if (geometry.type === 'LineString' || geometry.type === 'MultiLineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('stroke' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('stroke-width' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-width');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('step', '0.1').attr('value', '2');
+        }
+        if (!('stroke-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'stroke-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '1');
+        }
+      }
+      if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+        if (!('fill' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill');
+          tr.append('td').append('input').attr('type', 'color').attr('value', '#555555');
+        }
+        if (!('fill-opacity' in properties)) {
+          let tr = sel.select('table.marker-properties tbody').insert('tr');
+          tr.append('th').append('input').attr('type', 'text').attr('value', 'fill-opacity');
+          tr.append('td').append('input').attr('type', 'number').attr('min', '0').attr('max', '1').attr('step', '0.1').attr('value', '0.5');
+        }
+      }
     }
   };
 };


### PR DESCRIPTION
Handles the `marker-size` simplestyle-spec property.   (this was not included in #718 for some reason) `marker-icon` is the only remaining unsupported simplestyle property.

Restores simplestyle property creation/editing in the popup UI (Closes #756) with the following changes:

- Instead of a checkbox, there is a text button `Add Simplestyle Properties`.  When clicked, it appends the style properties for the current feature type to the properties table.  These will not take effect until the user clicks the save button.   (the previous implementation always included the style rows, but hid the rows, so they would be added on save whether the user wanted them or not. #498)

- Adds some logic to determine whether to show the `Add Simplestyle Properties` button (do not show it if all of the properties for a given geometry type already exist in the feature's properties.
