### PR TITLE
handle null properties when rendering MultiPoint

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -80175,7 +80175,7 @@ const addMarkers = (geojson, context, writable) => {
             type: 'Point',
             coordinates: coordinatePair
           },
-          properties,
+          properties || {},
           index
         );
       });

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -57,7 +57,7 @@ const addMarkers = (geojson, context, writable) => {
             type: 'Point',
             coordinates: coordinatePair
           },
-          properties,
+          properties || {},
           index
         );
       });


### PR DESCRIPTION
Tiny bugfix for handling MultiPoint rendering when properties is `null`. 

Diccovered when testing a MultiPoint URL from #661 

[Test URL ](http://geojson.io/#data=data:application/json,%7B%22type%22%3A%22MultiPoint%22%2C%22coordinates%22%3A%5B%5B-122.3858692%2C47.56452925%5D%2C%5B-122.387177%2C47.561455%5D%2C%5B-122.38679%2C47.562161%5D%2C%5B-122.386375%2C47.568764%5D%2C%5B-122.41095%2C47.577553%5D%2C%5B-122.3870841%2C47.5614664%5D%2C%5B-122.407364%2C47.577271%5D%2C%5B-122.386637%2C47.579173%5D%2C%5B-122.385849%2C47.562884%5D%2C%5B-122.4109498%2C47.5775947%5D%2C%5B-122.3869421%2C47.5819689%5D%2C%5B-122.40967%2C47.57968%5D%2C%5B-122.386024%2C47.583717%5D%2C%5B-122.386383%2C47.56538%5D%2C%5B-122.3847046%2C47.5826992%5D%5D%7D)