### PR TITLE
show geojsonhint warnings without rejecting geojson

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -195,8 +195,16 @@ button.delete-invert:hover {
   -webkit-transition: all 100ms;
 }
 
+.error-marker.warning {
+  background: #eee0aa;
+}
+
 .error-marker:hover {
   background: #d68;
+}
+
+.error-marker.warning:hover {
+  background: #eee0aa;
 }
 
 .error-marker:before {

--- a/dist/site.js
+++ b/dist/site.js
@@ -77368,6 +77368,12 @@ module.exports = function (callback) {
     const err = geojsonhint.hint(editor.getValue());
     editor.clearGutter('error');
 
+    // check err for objects that don't have `level` properties
+    // if any exist, reject the geojson
+    const rejectableErrors = err.filter(
+      (d) => !Object.prototype.hasOwnProperty.call(d, 'level')
+    );
+
     if (err instanceof Error) {
       handleError(err.message);
       return callback({
@@ -77375,7 +77381,7 @@ module.exports = function (callback) {
         title: 'invalid JSON',
         message: 'invalid JSON'
       });
-    } else if (err.length) {
+    } else if (rejectableErrors.length) {
       handleErrors(err);
       return callback({
         class: 'icon-circle-blank',
@@ -77383,6 +77389,10 @@ module.exports = function (callback) {
         message: 'invalid GeoJSON'
       });
     } else {
+      // err should only include warnings at this point
+      // accept the geojson as valid but show the warnings
+      handleErrors(err);
+
       const zoom =
         changeObj.from.ch === 0 &&
         changeObj.from.line === 0 &&
@@ -77416,14 +77426,19 @@ module.exports = function (callback) {
     function handleErrors(errors) {
       editor.clearGutter('error');
       errors.forEach((e) => {
-        editor.setGutterMarker(e.line, 'error', makeMarker(e.message));
+        editor.setGutterMarker(e.line, 'error', makeMarker(e.message, e.level));
       });
     }
 
-    function makeMarker(msg) {
+    function makeMarker(msg, level) {
+      let className = 'error-marker';
+      if (level === 'message') {
+        className += ' warning';
+      }
+
       return d3
         .select(document.createElement('div'))
-        .attr('class', 'error-marker')
+        .attr('class', className)
         .attr('message', msg)
         .node();
     }


### PR DESCRIPTION
Status Quo:

geojson in the code editor is validated using `geojsonhint` which returns an array of error objects.  If this array is not empty, the geojson is considered invalid and is not rendered/updated, and the errors are highlighted in red in the codemirror gutter.

In this PR:

- Checks the array returned from geojsonhint for objects that do not contain a `level` property.  These are "rejectable" errors and if any of these exist, reject the geojson and highlight the errors in the same way as the status quo.
- When geojson does not yield any rejectable errors from geojsonhint, accept it, but also highlight any warnings in yellow.

Example: Feature missing `properties` key yields an error, polygon that does not follow the right-hand-rule yields a warning.

<img width="617" alt="Cursor_and_geojson_io___powered_by_Mapbox" src="https://user-images.githubusercontent.com/1833820/202090679-65e4c431-1862-430a-91a8-818cfefa915f.png">


Closes #784