### PR TITLE
update core style urls

### DIFF
--- a/dist/site.js
+++ b/dist/site.js
@@ -94703,11 +94703,47 @@ module.exports = function (context, readonly) {
         !context.map.getSource('map-data')
       ) {
         const { name } = context.map.getStyle();
+
         let color = DARK_FEATURE_COLOR;
         if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
           color = LIGHT_FEATURE_COLOR;
         }
-        context.map.setFog({});
+
+        // setFog only on Light and Dark
+        if (['Mapbox Light', 'Mapbox Dark', 'osm'].includes(name)) {
+          context.map.setFog({
+            range: [0.5, 10],
+            color: '#ffffff',
+            'high-color': '#245cdf',
+            'space-color': [
+              'interpolate',
+              ['linear'],
+              ['zoom'],
+              4,
+              '#010b19',
+              7,
+              '#367ab9'
+            ],
+            'horizon-blend': [
+              'interpolate',
+              ['exponential', 1.2],
+              ['zoom'],
+              5,
+              0.02,
+              7,
+              0.08
+            ],
+            'star-intensity': [
+              'interpolate',
+              ['linear'],
+              ['zoom'],
+              5,
+              0.35,
+              6,
+              0
+            ]
+          });
+        }
 
         context.map.addSource('map-data', {
           type: 'geojson',
@@ -94857,23 +94893,23 @@ module.exports = function (context, readonly) {
 module.exports = [
   {
     title: 'Streets',
-    style: 'mapbox://styles/mapbox/streets-v11'
+    style: 'mapbox://styles/mapbox/streets-v12'
   },
   {
     title: 'Satellite Streets',
-    style: 'mapbox://styles/mapbox/satellite-streets-v11'
+    style: 'mapbox://styles/mapbox/satellite-streets-v12'
   },
   {
     title: 'Outdoors',
-    style: 'mapbox://styles/mapbox/outdoors-v11'
+    style: 'mapbox://styles/mapbox/outdoors-v12'
   },
   {
     title: 'Light',
-    style: 'mapbox://styles/mapbox/light-v10'
+    style: 'mapbox://styles/mapbox/light-v11'
   },
   {
     title: 'Dark',
-    style: 'mapbox://styles/mapbox/dark-v10'
+    style: 'mapbox://styles/mapbox/dark-v11'
   },
   {
     title: 'OSM',

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -284,11 +284,47 @@ module.exports = function (context, readonly) {
         !context.map.getSource('map-data')
       ) {
         const { name } = context.map.getStyle();
+
         let color = DARK_FEATURE_COLOR;
         if (['Mapbox Satellite Streets', 'Mapbox Dark'].includes(name)) {
           color = LIGHT_FEATURE_COLOR;
         }
-        context.map.setFog({});
+
+        // setFog only on Light and Dark
+        if (['Mapbox Light', 'Mapbox Dark', 'osm'].includes(name)) {
+          context.map.setFog({
+            range: [0.5, 10],
+            color: '#ffffff',
+            'high-color': '#245cdf',
+            'space-color': [
+              'interpolate',
+              ['linear'],
+              ['zoom'],
+              4,
+              '#010b19',
+              7,
+              '#367ab9'
+            ],
+            'horizon-blend': [
+              'interpolate',
+              ['exponential', 1.2],
+              ['zoom'],
+              5,
+              0.02,
+              7,
+              0.08
+            ],
+            'star-intensity': [
+              'interpolate',
+              ['linear'],
+              ['zoom'],
+              5,
+              0.35,
+              6,
+              0
+            ]
+          });
+        }
 
         context.map.addSource('map-data', {
           type: 'geojson',

--- a/src/ui/map/styles.js
+++ b/src/ui/map/styles.js
@@ -1,23 +1,23 @@
 module.exports = [
   {
     title: 'Streets',
-    style: 'mapbox://styles/mapbox/streets-v11'
+    style: 'mapbox://styles/mapbox/streets-v12'
   },
   {
     title: 'Satellite Streets',
-    style: 'mapbox://styles/mapbox/satellite-streets-v11'
+    style: 'mapbox://styles/mapbox/satellite-streets-v12'
   },
   {
     title: 'Outdoors',
-    style: 'mapbox://styles/mapbox/outdoors-v11'
+    style: 'mapbox://styles/mapbox/outdoors-v12'
   },
   {
     title: 'Light',
-    style: 'mapbox://styles/mapbox/light-v10'
+    style: 'mapbox://styles/mapbox/light-v11'
   },
   {
     title: 'Dark',
-    style: 'mapbox://styles/mapbox/dark-v10'
+    style: 'mapbox://styles/mapbox/dark-v11'
   },
   {
     title: 'OSM',


### PR DESCRIPTION
Core styles updates launched today!

https://www.mapbox.com/blog/mapbox-core-styles-redesigns

Edit:  Since some of the core styles include fog, we drop the `setFog()` that happens on each style change.  Instead we use the style's fog settings  for Streets, Satellite-Streets, and Outdoors.  For the other styles we manually set the fog.  