### PR TITLE
require shift key to drag features, update help text

### DIFF
--- a/data/help.html
+++ b/data/help.html
@@ -30,9 +30,12 @@
 <p>Note: Circles are not supported in GeoJSON, so the circle drawing tool is really creating a circle-shaped polygon
     with 64 vertices.</p>
 
-<p>Properties in GeoJSON are stored as 'key value pairs' - so, for instance,
-    if you wanted to add a name to each feature, type 'name' in the first table
-    field, and the name of the feature in the second.</p>
+<h3>I want to edit features</h3>
+
+<p>To edit geometries, click the edit button to enter editng mode. All Features are selected by default. Click to select a Feature or Vertex. Press delete to remove selected Feature or Vertex. Drag to move selected vertex. Shift + drag to move selected Feature(s)</p>
+
+<p>Properties in GeoJSON are stored as 'key value pairs'. You can edit properties in three ways: 1 - Click the feature on the map and edit properties in the popup. 2 - Edit properties in the data table, 3 - Edit properties in the Code editor</p>
+
 
 <h3>I'm a coder</h3>
 

--- a/src/ui/draw/direct_select.js
+++ b/src/ui/draw/direct_select.js
@@ -1,0 +1,21 @@
+const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+
+const DirectSelect = {
+  ...MapboxDraw.modes.direct_select,
+  onDrag: function (state, e) {
+    if (state.canDragMove !== true) return;
+    state.dragMoving = true;
+    e.originalEvent.stopPropagation();
+
+    const delta = {
+      lng: e.lngLat.lng - state.dragMoveLocation.lng,
+      lat: e.lngLat.lat - state.dragMoveLocation.lat
+    };
+    if (state.selectedCoordPaths.length > 0) this.dragVertex(state, e, delta);
+    else if (e.originalEvent.shiftKey) this.dragFeature(state, e, delta);
+
+    state.dragMoveLocation = e.lngLat;
+  }
+};
+
+module.exports = DirectSelect;

--- a/src/ui/draw/simple_select.js
+++ b/src/ui/draw/simple_select.js
@@ -1,0 +1,13 @@
+const MapboxDraw = require('@mapbox/mapbox-gl-draw');
+
+const SimpleSelect = {
+  ...MapboxDraw.modes.simple_select,
+  onDrag: function (state, e) {
+    if (state.canDragMove && e.originalEvent.shiftKey)
+      return this.dragMove(state, e);
+    if (this.drawConfig.boxSelect && state.canBoxSelect)
+      return this.whileBoxSelect(state, e);
+  }
+};
+
+module.exports = SimpleSelect;

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -8,6 +8,8 @@ const MapboxGeocoder = require('@mapbox/mapbox-gl-geocoder');
 const DrawLineString = require('../draw/linestring');
 const DrawRectangle = require('../draw/rectangle');
 const DrawCircle = require('../draw/circle');
+const SimpleSelect = require('../draw/simple_select');
+const DirectSelect = require('../draw/direct_select');
 const ExtendDrawBar = require('../draw/extend_draw_bar');
 const { EditControl, SaveCancelControl, TrashControl } = require('./controls');
 const { geojsonToLayer, bindPopup } = require('./util');
@@ -118,6 +120,8 @@ module.exports = function (context, readonly) {
         displayControlsDefault: false,
         modes: {
           ...MapboxDraw.modes,
+          simple_select: SimpleSelect,
+          direct_select: DirectSelect,
           draw_line_string: DrawLineString,
           draw_rectangle: DrawRectangle,
           draw_circle: DrawCircle


### PR DESCRIPTION
Closes https://github.com/mapbox/geojson.io/issues/780 by making it more difficult to move entire features.

Requires Shift + drag to move one or more selected features.
Documents this in help.html along with some other editing tips