### PR TITLE
restore console api, update API.md to document it

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,9 @@
 ## Geojson.io API
 
-You can interact with geojson.io programmatically via url parameters:
+You can interact with geojson.io programmatically in two ways:
+
+* [URL parameters](#url-api)
+* [Browser console](#console-api)
 
 ## URL API
 
@@ -63,3 +66,49 @@ The url is in the form:
 #### Example:
 
 http://geojson.io/#id=github:benbalter/dc-wifi-social/blob/master/bars.geojson&map=14/38.9140/-77.0302
+
+## Console API
+
+Pop open your browser console and see the beautiful examples: geojson.io has started to expose a subset of its inner workings for you to mess around with:
+
+
+### `window.api.map`
+
+The [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/guides/) map that you see and use on the site. See the [Mapbox GL JS API Reference](https://docs.mapbox.com/mapbox-gl-js/api/) for all the things you can do with it.
+
+For instance, you could add another map source and layer:
+
+```js
+window.api.map.addSource('raster-tiles', {
+    'type': 'raster',
+    'tiles': [
+    'https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
+    ],
+    'tileSize': 256,
+    'attribution':
+    'Map tiles by <a target="_top" rel="noopener" href="http://stamen.com">Stamen Design</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" rel="noopener" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
+})
+
+window.api.map.addLayer({
+    'id': 'simple-tiles',
+    'type': 'raster',
+    'source': 'raster-tiles',
+    'minzoom': 0,
+    'maxzoom': 22
+})
+```
+
+### `window.api.data`
+
+The data model. See the [code to get an idea of how it works](https://github.com/mapbox/geojson.io/blob/main/src/core/data.js#L46-L101) -
+you'll want to use stuff like `data.set({ map: { .. your geojson map information .. })`
+and `data.get('map')` and `data.mergeFeatures([arrayoffeatures])` to do your
+dirty business.
+
+## `window.api.draw`
+
+Exposes the [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) instance in the console.
+
+## `window.api.on(event, fn)`
+
+Exposes d3 events, including `change`.

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -1,0 +1,55 @@
+module.exports = api;
+
+function api(context) {
+  if (typeof console === 'undefined' || !console || !console.log) return;
+
+  console.log(
+    '%c⚛ geojson.io console api ⚛',
+    'font-family:monospace;font-size:20px;color:darkblue;'
+  );
+  console.log(
+    '%cfrom here, you can customize geojson.io to your liking by mucking around with the internals',
+    'font-family:monospace;font-size:14px;color:darkblue;'
+  );
+  console.log("%chere's what's available ↓", 'color:blue;');
+  console.log('');
+
+  console.log(
+    '%c- window.api.map: the mapboxgl map object',
+    'font-weight:bold;'
+  );
+  console.log('%O', context.map);
+
+  console.log(
+    '%c- window.api.draw: the mapbox-gl-draw instance',
+    'font-weight:bold;'
+  );
+  console.log('%O', context.Draw);
+
+  console.log('');
+
+  console.log('%c- window.api.data: the data model', 'font-weight:bold;');
+  console.log('%O', context.data);
+
+  console.log('');
+  console.log('%cExample:', 'font-weight:bold;');
+  console.log('');
+  console.log(
+    '%c  window.api.map.flyTo({ center: [-78, 38], zoom: 5 });',
+    'color:green;'
+  );
+
+  console.log('');
+  console.log(
+    '%c  window.api.data.mergeFeatures([{ type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [0, 0] } }]);',
+    'color:green;'
+  );
+
+  window.api = {
+    map: context.map,
+    draw: context.Draw,
+    data: context.data
+  };
+
+  d3.rebind(window.api, context.dispatch, 'on');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ const ui = require('./ui'),
   recovery = require('./core/recovery'),
   repo = require('./core/repo'),
   user = require('./core/user'),
+  api = require('./core/api'),
   store = require('store');
 
 const gjIO = geojsonIO(),
@@ -46,6 +47,8 @@ d3.select('.geojsonio').call(gjUI);
 
 gjIO.recovery = recovery(gjIO);
 gjIO.router.on();
+
+api(gjIO);
 
 function geojsonIO() {
   const context = {};

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -105,8 +105,6 @@ module.exports = function (context, readonly) {
       hash: 'map'
     });
 
-    window.map = context.map;
-
     if (writable) {
       context.map.addControl(
         new MapboxGeocoder({


### PR DESCRIPTION
Restores the geojson.io `console api` with `map`, `draw`, and `data` properties available on `window.api`.  `API.md` is also restored to include documentation for the console api, with updated links (and references to leaflet and leaflet draw replaced with mapboxgl and mapbox-gl-draw)

Closes #806 