### PR TITLE
Speed up the flying animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Full API documentation can be found in [API.md](API.md).
 
 `rollup` can take several seconds to build before changes appear in the browser.
 
+If you get an error resolving dependencies related to `rollup` on newer versions of node, then try `npm install --force` and be sure to not commit changes to `package-lock.json`.
+
 ## Production Build & Deployment
 
 `npm run build` will create minified bundles in `/dist`. You can try out the production build with `npm run serve` which will run live-server.

--- a/src/lib/zoomextent.js
+++ b/src/lib/zoomextent.js
@@ -9,12 +9,14 @@ module.exports = function (context) {
   ) {
     context.map.flyTo({
       center: geojson.features[0].geometry.coordinates,
-      zoom: 6
+      zoom: 6,
+      duration: 1000
     });
   } else {
     const bounds = bbox(geojson);
     context.map.fitBounds(bounds, {
-      padding: 50
+      padding: 50,
+      duration: 1000
     });
   }
 };


### PR DESCRIPTION
Before, opening a file from the default globe view takes about 5s to zoom in. This feels excessive to me:

https://user-images.githubusercontent.com/1664407/212032226-3ae3b2cd-6780-447d-a586-76278d5b3d1b.mp4

I've capped it in this PR to 1s:

https://user-images.githubusercontent.com/1664407/212032290-15acf646-1850-4e7d-8606-e0a2424019a3.mp4

This feels much more convenient to me, but it is an opinionated design question, so happy for other ideas. Also, the change affects other uses of `zoomextent`, like clicking "Zoom to features", loading WKB text, etc.