### PR TITLE
update external geojson example link

### DIFF
--- a/API.md
+++ b/API.md
@@ -39,7 +39,7 @@ The URL should be encoded as per `encodeURIComponent(url)`.
 
 #### Example:
 
-http://geojson.io/#data=data:text/x-url,http%3A%2F%2Fapi.tiles.mapbox.com%2Fv3%2Ftmcw.map-gdv4cswo%2Fmarkers.geojson
+http://geojson.io/#data=data:text/x-url,https%3A%2F%2Fraw.githubusercontent.com%2Fcodeforgermany%2Fclick_that_hood%2Fmain%2Fpublic%2Fdata%2Fcalifornia-counties.geojson
 
 ### `id=gist:`
 


### PR DESCRIPTION
Updates the example link for the `data=data:text/x-url` url parameter.  The old link was from a legacy mapbox api call that now returns an error message instead of geojson.

The new example uses a geojson file hosted on github for counties in the U.S. state of California.