### PR TITLE
calculate geometry info based on the full feature

### DIFF
--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -172,7 +172,11 @@ function geojsonToLayer(context, writable) {
 }
 
 function bindPopup(e, context, writable) {
-  const [feature] = e.features;
+  // build the popup using the actual feature from the data store,
+  // not the feature returned from queryRenderedFeatures()
+  const { id } = e.features[0];
+  const feature = context.data.get('map').features[id];
+
   const props = feature.properties;
   let table = '';
   let info = '';


### PR DESCRIPTION
Fixes #816 by fetching the full feature from the datastore before doing geometry calculations.  (use the feature returned by queryRenderedFeatures() only for getting the feature id, fetch the full feature by its id, then perform calculations.