### PR TITLE
fix popup buttons

### DIFF
--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -177,6 +177,9 @@ function bindPopup(e, context, writable) {
   const { id } = e.features[0];
   const feature = context.data.get('map').features[id];
 
+  // the id is needed when clicking buttons in the popup, but only exists on the feature after it is added to the map
+  feature.id = id;
+
   const props = feature.properties;
   let table = '';
   let info = '';


### PR DESCRIPTION
Fixes a regression introduced in #819 which broke buttons and within the popups.  Features are given an `id` property after being added to the map based on its position in the FeatureCollection, but this property may not exist on the data in the datastore.

#819 gets the `id` from `queryRenderedFeatures`, then uses it to look up the full feature from the datastore (by its index).   However, the retrieved feature does not include an `id` itself, so the "save" and "add simplestyle properties" buttons do not know which feature to update and an error is thrown.

Fixes #823 and #824