### PR TITLE
fix circle draw bug, upgrade mapbox-gl-draw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mapbox/geojsonhint": "^3.1.0",
         "@mapbox/gist-map-browser": "0.2.1",
         "@mapbox/github-file-browser": "0.6.1",
-        "@mapbox/mapbox-gl-draw": "^1.3.0",
+        "@mapbox/mapbox-gl-draw": "^1.4.1",
         "@mapbox/mapbox-gl-geocoder": "^5.0.1",
         "@mapbox/polyline": "^1.1.1",
         "@placemarkio/tokml": "^0.3.3",
@@ -802,12 +802,12 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-draw": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.3.0.tgz",
-      "integrity": "sha512-B+KWK+dAgzLHMNyKVuuMRfjeSlQ77MhNLdfpQQpbp3pkhnrdmydDe3ixto1Ua78hktNut0WTrAaD8gYu4PVcjA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.1.tgz",
+      "integrity": "sha512-g6F49KZagF9269/IoF6vZJeail6qtoc5mVF3eVRikNT7UFnY0QASfe2y53mgE99s6GrHdpV+PZuFxaL71hkMhg==",
       "dependencies": {
         "@mapbox/geojson-area": "^0.2.2",
-        "@mapbox/geojson-extent": "^1.0.0",
+        "@mapbox/geojson-extent": "^1.0.1",
         "@mapbox/geojson-normalize": "^0.0.1",
         "@mapbox/point-geometry": "^0.1.0",
         "hat": "0.0.3",
@@ -4254,6 +4254,14 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/get-stream": {
@@ -9850,6 +9858,11 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
+    "node_modules/wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10672,12 +10685,12 @@
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="
     },
     "@mapbox/mapbox-gl-draw": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.3.0.tgz",
-      "integrity": "sha512-B+KWK+dAgzLHMNyKVuuMRfjeSlQ77MhNLdfpQQpbp3pkhnrdmydDe3ixto1Ua78hktNut0WTrAaD8gYu4PVcjA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.1.tgz",
+      "integrity": "sha512-g6F49KZagF9269/IoF6vZJeail6qtoc5mVF3eVRikNT7UFnY0QASfe2y53mgE99s6GrHdpV+PZuFxaL71hkMhg==",
       "requires": {
         "@mapbox/geojson-area": "^0.2.2",
-        "@mapbox/geojson-extent": "^1.0.0",
+        "@mapbox/geojson-extent": "^1.0.1",
         "@mapbox/geojson-normalize": "^0.0.1",
         "@mapbox/point-geometry": "^0.1.0",
         "hat": "0.0.3",
@@ -13304,6 +13317,11 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
     },
     "get-stream": {
       "version": "6.0.1",
@@ -17524,6 +17542,11 @@
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         }
       }
+    },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@mapbox/geojsonhint": "^3.1.0",
     "@mapbox/gist-map-browser": "0.2.1",
     "@mapbox/github-file-browser": "0.6.1",
-    "@mapbox/mapbox-gl-draw": "^1.3.0",
+    "@mapbox/mapbox-gl-draw": "^1.4.1",
     "@mapbox/mapbox-gl-geocoder": "^5.0.1",
     "@mapbox/polyline": "^1.1.1",
     "@placemarkio/tokml": "^0.3.3",

--- a/src/ui/draw/circle.js
+++ b/src/ui/draw/circle.js
@@ -44,6 +44,11 @@ const CircleMode = {
   },
 
   onStop: function (state) {
+    this.activateUIButton();
+
+    // check to see if we've deleted this feature
+    if (this.getFeature(state.line.id) === undefined) return;
+
     // remove last added coordinate
     state.line.removeCoordinate('0');
     if (state.line.isValid()) {


### PR DESCRIPTION
Fixes #827.  The circle draw tool is an extension of the built-in linestring draw tool.  Some code was not copied over in the `onStop` method, which resulted in an endless loop.

- Updates `mapbox-gl-draw` to the latest, v1.4.1