### PR TITLE
add ga4 tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,14 @@
     ga("create", "UA-12158002-18", "auto");
     ga("send", "pageview");
   </script>
+  <!-- Google tag (gtag.js) -->
+  <script async src=“https://www.googletagmanager.com/gtag/js?id=G-3K6EEFGNP0”></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G - 3K6EEFGNP0');
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Adds a script tag for the new Google Analytics 4 tracking.  Leaves the old GA tracking script in place, which we can remove once the service is retired.