### PR TITLE
Fixed a bug when editing geometry in OSM style

### DIFF
--- a/src/ui/map/styles.js
+++ b/src/ui/map/styles.js
@@ -24,6 +24,7 @@ module.exports = [
     style: {
       name: 'osm',
       version: 8,
+      glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
       sources: {
         'osm-raster-tiles': {
           type: 'raster',


### PR DESCRIPTION
Fixes #812 

When using text-field for symbold in mapbox-gl-js, glyphs is required.
https://github.com/mapbox/mapbox-gl-js/blob/ec307c74bfe46f02e2b6f7292332caa5779a3f2e/src/style-spec/validate/validate_property.js#L54

