### PR TITLE
Fix import bug when missing geometry

### DIFF
--- a/src/lib/zoomextent.js
+++ b/src/lib/zoomextent.js
@@ -4,7 +4,7 @@ module.exports = function (context) {
   const geojson = context.data.get('map');
   // if the data is a single point, flyTo()
   if (
-    geojson.features.length === 1 &&
+    geojson.features.filter((feature) => feature.geometry).length === 1 &&
     geojson.features[0].geometry.type === 'Point'
   ) {
     context.map.flyTo({

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -160,8 +160,15 @@ function geojsonToLayer(context, writable) {
   const workingDatasetSource = context.map.getSource('map-data');
 
   if (workingDatasetSource) {
-    workingDatasetSource.setData(addIds(geojson));
-    addMarkers(geojson, context, writable);
+    const filteredFeatures = geojson.features.filter(
+      (feature) => feature.geometry
+    );
+    const filteredGeojson = {
+      type: 'FeatureCollection',
+      features: filteredFeatures
+    };
+    workingDatasetSource.setData(addIds(filteredGeojson));
+    addMarkers(filteredGeojson, context, writable);
     if (context.data.get('recovery')) {
       zoomextent(context);
       context.data.set({


### PR DESCRIPTION
Fixes #713 
Features that do not include geometry are not displayed on the map as markers and can be imported.
The geojson will be displayed in the right panel, same as when you copy and paste.