### PR TITLE
bump geojsonhint to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,10 @@
         "@mapbox/geojson-extent": "^1.0.1",
         "@mapbox/geojson-normalize": "0.0.1",
         "@mapbox/geojson-rewind": "0.5.2",
-        "@mapbox/geojsonhint": "^3.1.0",
+        "@mapbox/geojsonhint": "^3.2.0",
         "@mapbox/gist-map-browser": "0.2.1",
         "@mapbox/github-file-browser": "0.6.1",
+        "@mapbox/maki": "^8.0.1",
         "@mapbox/mapbox-gl-draw": "1.4.1",
         "@mapbox/mapbox-gl-geocoder": "^5.0.1",
         "@mapbox/polyline": "^1.1.1",
@@ -729,23 +730,14 @@
         "geojson-rewind": "geojson-rewind"
       }
     },
-    "node_modules/@mapbox/geojson-rewind/node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@mapbox/geojsonhint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-3.1.0.tgz",
-      "integrity": "sha512-GKyjCP5XqFw9ImJyB7n0kbh/p7ZSOzM/dUB/AS5ZbTk+3DDvogHF7qVvB9KHgtOROcXBe0kF0/J1NmsNDtPSMg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-3.2.0.tgz",
+      "integrity": "sha512-2gvaeDq0uGZ2jiKsdKBd2u3HJD6h0H1GzDnZjH3nVQHyyig3aNFNrMMqDYn0XipkQvkKGU96Y971qsJM1qpDdw==",
       "dependencies": {
         "concat-stream": "^1.6.1",
         "jsonlint-lines": "1.7.1",
-        "minimist": "^1.2.5",
-        "underscore": "1.12.1",
+        "minimist": "^1.2.8",
         "vfile": "^4.0.0",
         "vfile-reporter": "^5.1.1"
       },
@@ -767,11 +759,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/@mapbox/geojsonhint/node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/@mapbox/gist-map-browser": {
       "version": "0.2.1",
@@ -798,6 +785,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/@mapbox/maki": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/maki/-/maki-8.0.1.tgz",
+      "integrity": "sha512-2/83/Lm1W9GiqnYHXzmpN6EtfGf01O+iLAM/3qD9Whdrqz22Nwy6RniDMAomi9uFM6W0eoeqYDIQHxb/kB/Bfg=="
     },
     "node_modules/@mapbox/mapbox-gl-draw": {
       "version": "1.4.1",
@@ -6234,9 +6226,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10555,24 +10547,16 @@
       "requires": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
-        }
       }
     },
     "@mapbox/geojsonhint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-3.1.0.tgz",
-      "integrity": "sha512-GKyjCP5XqFw9ImJyB7n0kbh/p7ZSOzM/dUB/AS5ZbTk+3DDvogHF7qVvB9KHgtOROcXBe0kF0/J1NmsNDtPSMg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-3.2.0.tgz",
+      "integrity": "sha512-2gvaeDq0uGZ2jiKsdKBd2u3HJD6h0H1GzDnZjH3nVQHyyig3aNFNrMMqDYn0XipkQvkKGU96Y971qsJM1qpDdw==",
       "requires": {
         "concat-stream": "^1.6.1",
         "jsonlint-lines": "1.7.1",
-        "minimist": "^1.2.5",
-        "underscore": "1.12.1",
+        "minimist": "^1.2.8",
         "vfile": "^4.0.0",
         "vfile-reporter": "^5.1.1"
       },
@@ -10585,11 +10569,6 @@
             "JSV": ">= 4.0.x",
             "nomnom": ">= 1.5.x"
           }
-        },
-        "underscore": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         }
       }
     },
@@ -10615,6 +10594,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="
+    },
+    "@mapbox/maki": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/maki/-/maki-8.0.1.tgz",
+      "integrity": "sha512-2/83/Lm1W9GiqnYHXzmpN6EtfGf01O+iLAM/3qD9Whdrqz22Nwy6RniDMAomi9uFM6W0eoeqYDIQHxb/kB/Bfg=="
     },
     "@mapbox/mapbox-gl-draw": {
       "version": "1.4.1",
@@ -14744,9 +14728,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@mapbox/geojson-extent": "^1.0.1",
     "@mapbox/geojson-normalize": "0.0.1",
     "@mapbox/geojson-rewind": "0.5.2",
-    "@mapbox/geojsonhint": "^3.1.0",
+    "@mapbox/geojsonhint": "^3.2.0",
     "@mapbox/gist-map-browser": "0.2.1",
     "@mapbox/github-file-browser": "0.6.1",
     "@mapbox/maki": "^8.0.1",


### PR DESCRIPTION
Updates geojsonhint to v3.2.0 which ignores a top-level crs property.  Closes #849