### PR TITLE
handle streets style in storage

### DIFF
--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -98,6 +98,12 @@ module.exports = function (context, readonly) {
 
     const projection = context.storage.get('projection') || DEFAULT_PROJECTION;
     const activeStyle = context.storage.get('style') || DEFAULT_STYLE;
+
+    // handle previous users who had Streets selected
+    if (activeStyle === 'Streets') {
+      activeStyle === 'Standard';
+    }
+
     const { style } = styles.find((d) => d.title === activeStyle);
 
     context.map = new mapboxgl.Map({


### PR DESCRIPTION
Handles the case where `Streets` is kept in localstorage as the active style, causing a blank map because Streets has been replaced with Mapbox Standard.