### PR TITLE
fix streets storage handling

### DIFF
--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -97,11 +97,11 @@ module.exports = function (context, readonly) {
     );
 
     const projection = context.storage.get('projection') || DEFAULT_PROJECTION;
-    const activeStyle = context.storage.get('style') || DEFAULT_STYLE;
+    let activeStyle = context.storage.get('style') || DEFAULT_STYLE;
 
     // handle previous users who had Streets selected
     if (activeStyle === 'Streets') {
-      activeStyle === 'Standard';
+      activeStyle = 'Standard';
     }
 
     const { style } = styles.find((d) => d.title === activeStyle);


### PR DESCRIPTION
Fixes a previous fix to handle `Streets` being stored in localstorage as the active style.