### PR TITLE
UI:  New Window with GeoJSON URL

### DIFF
--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -87,6 +87,20 @@ module.exports = function fileBar(context) {
             }
           },
           {
+            title: '🪟 New Window with GeoJSON URL',
+            action: function () {
+              const geojsonURL = prompt(
+                'Load GeoJSON data from a URL\n\n Warning this will open a new window 🪟'
+              );
+              if (geojsonURL === null) return;
+
+              const encodedURL = encodeURIComponent(geojsonURL);
+              const openURL = `${window.location.origin}${window.location.pathname}#data=data:text/x-url,${encodedURL}`;
+              console.log(openURL);
+              window.open(openURL);
+            }
+          },
+          {
             title: 'Zoom to features',
             alt: 'Zoom to the extent of all features',
             action: function () {


### PR DESCRIPTION
The API notes states that a URL of GeoJSON data can be encoded to open directly in <https://geojson.io>.  This PR adds that functionality to the user interface: 

* Update the User Interface > Meta > 🪟 New Window with GeoJSON URL

---

source: [API.md](https://github.com/mapbox/geojson.io/blob/main/API.md#datadataapplicationjson)

> "*Open the map and load a chunk of GeoJSON data from a URL segment directly onto the map. The GeoJSON data should be encoded as per encodeURIComponent(JSON.stringify(geojson_data)).*"

---

#### Live Demo

Open a Weather Forecast from Yosemite National Park

Open the live demo of this UI update:
* <https://roblabs.com/geojson>
  * https://api.weather.gov/gridpoints/HNX/67,143/forecast
---

Putting it all together:
* <https://roblabs.com/geojson/#data=data:text/x-url,https%3A%2F%2Fapi.weather.gov%2Fgridpoints%2FHNX%2F67%2C143%2Fforecast&map=13.66/37.75138/-119.59428>
---

#### Video

Open GeoJSON from Weather.gov directly in <https://geojson.io>.

https://github.com/user-attachments/assets/31c37645-aba5-4357-8ff8-f484ee8de1b3


