### PR TITLE
Fix protocol in Markdown docs to be `https://`

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,14 +35,14 @@ Load GeoJSON data from a URL on the internet onto the map. The URL must
 refer directly to a resource that is:
 
 - Freely accessible (not behind a password)
-- Supports [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
+- Supports [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
 - Is valid GeoJSON
 
 The URL should be encoded as per `encodeURIComponent(url)`.
 
 #### Example:
 
-http://geojson.io/#data=data:text/x-url,https%3A%2F%2Fraw.githubusercontent.com%2Fcodeforgermany%2Fclick_that_hood%2Fmain%2Fpublic%2Fdata%2Fcalifornia-counties.geojson
+https://geojson.io/#data=data:text/x-url,https%3A%2F%2Fraw.githubusercontent.com%2Fcodeforgermany%2Fclick_that_hood%2Fmain%2Fpublic%2Fdata%2Fcalifornia-counties.geojson
 
 ### `id=gist:`
 
@@ -65,7 +65,7 @@ The url is in the form:
 
 #### Example:
 
-http://geojson.io/#id=github:benbalter/dc-wifi-social/blob/master/bars.geojson&map=14/38.9140/-77.0302
+https://geojson.io/#id=github:benbalter/dc-wifi-social/blob/master/bars.geojson&map=14/38.9140/-77.0302
 
 ## Console API
 
@@ -86,7 +86,7 @@ window.api.map.addSource('raster-tiles', {
     ],
     'tileSize': 256,
     'attribution':
-    'Map tiles by <a target="_top" rel="noopener" href="http://stamen.com">Stamen Design</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" rel="noopener" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
+    'Map tiles by <a target="_top" rel="noopener" href="https://stamen.com">Stamen Design</a>, under <a target="_top" rel="noopener" href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" rel="noopener" href="https://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" rel="noopener" href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
 })
 
 window.api.map.addLayer({

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A fast, simple editor for map data. Read more on [Mapbox](https://www.mapbox.com
 
 You can interact with geojson.io programmatically via URL parameters. Here is an example of geojson encoded into the URL:
 
-http://geojson.io/#data=data:application/json,%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0%2C0%5D%2C%5B10%2C10%5D%5D%7D
+https://geojson.io/#data=data:application/json,%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B0%2C0%5D%2C%5B10%2C10%5D%5D%7D
 
 Full API documentation can be found in [API.md](API.md).
 

--- a/data/help.md
+++ b/data/help.md
@@ -1,6 +1,6 @@
 ## Help
 
-**geojson.io** is a quick, simple tool for creating, viewing, and sharing maps. geojson.io is named after [GeoJSON](http://geojson.org/), an open source spatial data format, and it supports GeoJSON in all ways - but also accepts KML, GPX, CSV, GTFS, TopoJSON, and other formats.
+**geojson.io** is a quick, simple tool for creating, viewing, and sharing maps. geojson.io is named after [GeoJSON](https://geojson.org/), an open source spatial data format, and it supports GeoJSON in all ways - but also accepts KML, GPX, CSV, GTFS, TopoJSON, and other formats.
 
 Want to request a feature or report a bug? [Open an issue on geojson.io's issue tracker.](https://github.com/mapbox/geojson.io/issues?state=open)
 

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -87,6 +87,20 @@ module.exports = function fileBar(context) {
             }
           },
           {
+            title: '🪟 New Window with GeoJSON URL',
+            action: function () {
+              const geojsonURL = prompt(
+                'Load GeoJSON data from a URL\n\n Warning this will open a new window 🪟'
+              );
+              if (geojsonURL === null) return;
+
+              const encodedURL = encodeURIComponent(geojsonURL);
+              const openURL = `${window.location.origin}${window.location.pathname}#data=data:text/x-url,${encodedURL}`;
+              console.log(openURL);
+              window.open(openURL);
+            }
+          },
+          {
             title: 'Zoom to features',
             alt: 'Zoom to the extent of all features',
             action: function () {

--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -87,20 +87,6 @@ module.exports = function fileBar(context) {
             }
           },
           {
-            title: '🪟 New Window with GeoJSON URL',
-            action: function () {
-              const geojsonURL = prompt(
-                'Load GeoJSON data from a URL\n\n Warning this will open a new window 🪟'
-              );
-              if (geojsonURL === null) return;
-
-              const encodedURL = encodeURIComponent(geojsonURL);
-              const openURL = `${window.location.origin}${window.location.pathname}#data=data:text/x-url,${encodedURL}`;
-              console.log(openURL);
-              window.open(openURL);
-            }
-          },
-          {
             title: 'Zoom to features',
             alt: 'Zoom to the extent of all features',
             action: function () {


### PR DESCRIPTION
This PR fixes all instances in Markdown files where there was a reference to `http://`.  All public facing notes (API.md, help.md) now have `https://` as their protocol.