### PR TITLE
Adds segment tracking for this repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,9 @@
         "@mapbox/github-file-browser": "0.6.1",
         "@mapbox/maki": "^8.0.1",
         "@mapbox/mapbox-gl-draw": "1.4.1",
-        "@mapbox/mapbox-gl-geocoder": "^5.0.1",
+        "@mapbox/mapbox-gl-geocoder": "^5.0.2",
         "@mapbox/polyline": "^1.1.1",
+        "@mapbox/web-analytics": "^0.9.0",
         "@placemarkio/tokml": "^0.3.3",
         "@popperjs/core": "^2.11.6",
         "@sentry/browser": "^7.20.0",
@@ -42,7 +43,7 @@
         "geojson-random": "0.1.0",
         "geojson2dsv": "0.1.0",
         "lodash": "^4.17.21",
-        "mapbox-gl": "3.1.2",
+        "mapbox-gl": "^3.5.2",
         "numeral": "^2.0.6",
         "osmtogeojson": "3.0.0-beta.5",
         "polytogeojson": "0.0.1",
@@ -80,9 +81,6 @@
         "rollup-plugin-polyfill-node": "^0.11.0",
         "tailwindcss": "^3.2.3",
         "tape": "^5.6.1"
-      },
-      "engines": {
-        "node": "14"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -747,11 +745,11 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-geocoder": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-5.0.1.tgz",
-      "integrity": "sha512-/OUL42eh4OBaIerhcwCpa27oD+u4a2xN8V7vEdsglwd8lCplFAxJCdwT9Kprli1TH5mTYsXyONmh03FwoWBWfA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-5.0.3.tgz",
+      "integrity": "sha512-aeu2ZM+UKoMUGqqKy4UVVEKsIaNj2KSsiQ4p4YbNSAjZj2vcP33KSod+DPeRwhvoY+MU6KgyvdZ/1xdmH+C62g==",
       "dependencies": {
-        "@mapbox/mapbox-sdk": "^0.13.3",
+        "@mapbox/mapbox-sdk": "^0.16.1",
         "events": "^3.3.0",
         "lodash.debounce": "^4.0.6",
         "nanoid": "^3.1.31",
@@ -761,9 +759,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "mapbox-gl": ">= 0.47.0 < 3.0.0"
       }
     },
     "node_modules/@mapbox/mapbox-gl-geocoder/node_modules/xtend": {
@@ -775,14 +770,14 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="
     },
     "node_modules/@mapbox/mapbox-sdk": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.7.tgz",
-      "integrity": "sha512-JZjBsAVSBv7lX7gQPOQwftBGHIUcvL/tPKFxAL+SCT7u1n+eRH052XebOTkl28pNm7Du6DpKAs1GvgUnDcFFDQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.1.tgz",
+      "integrity": "sha512-dyZrmg+UL/Gp5mGG3CDbcwGSUMYYrfbd9hdp0rcA3pHSf3A9eYoXO9nFiIk6SzBwBVMzHENJz84ZHdqM0MDncQ==",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",
         "@mapbox/parse-mapbox-token": "^0.2.0",
@@ -931,6 +926,11 @@
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
+    },
+    "node_modules/@mapbox/web-analytics": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/web-analytics/-/web-analytics-0.9.0.tgz",
+      "integrity": "sha512-TGuAJ0bEKEHFdZr1gV93snrX8/A2NehDTgtquv4MANNMSIQ/mKp45Id6nyHlb9GUjVSaIMLrMmmSjZa6WER9yg=="
     },
     "node_modules/@mapbox/whoots-js": {
       "version": "3.1.0",
@@ -1454,14 +1454,14 @@
       }
     },
     "node_modules/@types/cacheable-request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dependencies": {
         "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
+        "@types/keyv": "^3.1.4",
         "@types/node": "*",
-        "@types/responselike": "*"
+        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/estree": {
@@ -1480,9 +1480,17 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -1495,17 +1503,31 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/keyv": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-4.2.0.tgz",
-      "integrity": "sha512-xoBtGl5R9jeKUhc8ZqeYaRDx04qqJ10yhhXYGmJ4Jr8qKpvMsDQQrNUvF/wUJ4klOtmJeJM+p2Xo3zp9uaC3tw==",
-      "deprecated": "This is a stub types definition. keyv provides its own type definitions, so you do not need this installed.",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dependencies": {
-        "keyv": "*"
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
       }
     },
     "node_modules/@types/minimatch": {
@@ -1529,6 +1551,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1536,9 +1563,9 @@
       "dev": true
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1548,6 +1575,14 @@
       "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.0.tgz",
       "integrity": "sha512-70xBJoLv+oXjB5PhtA8vo7erjLDp9/qqI63SRHm4REKrwuPOLs8HhXwlZJBJaB4kC18cCZ1UUZ6Fb/PLFW4TCA==",
       "dev": true
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -2180,9 +2215,9 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -2311,9 +2346,9 @@
       }
     },
     "node_modules/cheap-ruler": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-3.0.2.tgz",
-      "integrity": "sha512-02T332h1/HTN6cDSufLP8x4JzDs2+VC+8qZ/N0kWIVPyc2xUkWwWh3B2fJxR7raXkL4Mq7k554mfuM9ofv/vGg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -3176,9 +3211,9 @@
       "dev": true
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3978,9 +4013,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
+      "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4161,9 +4196,9 @@
       }
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
     },
     "node_modules/geojson2dsv": {
       "version": "0.1.0",
@@ -4349,9 +4384,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -4642,9 +4677,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5393,9 +5428,9 @@
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
     },
     "node_modules/keyv": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
-      "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6216,39 +6251,39 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.1.2.tgz",
-      "integrity": "sha512-+KoLEqZM8GxO/ViPz9tKgGURteKne+Y0pXiVCNsowymiZFH3FiL6dt9oZE95owMg5XqD3Kygz5mfchR1ZgmWlA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.7.0.tgz",
+      "integrity": "sha512-dCbVyH1uGobwv6f4QKRv2Z2wuVT/RmspsudK3sTxGRFxZi6Pd2P9axdbVyZpmGddCAREy44pHhvzvO0qgpdKAg==",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^2.0.1",
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/tiny-sdf": "^2.0.6",
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "cheap-ruler": "^3.0.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "^3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "cheap-ruler": "^4.0.0",
         "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
-        "kdbush": "^4.0.1",
+        "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^8.0.0",
-        "tinyqueue": "^2.0.3",
+        "quickselect": "^3.0.0",
+        "serialize-to-js": "^3.1.2",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
       }
-    },
-    "node_modules/mapbox-gl/node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7409,9 +7444,9 @@
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7469,9 +7504,9 @@
       }
     },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -8169,6 +8204,14 @@
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-to-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
+      "integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -9111,9 +9154,9 @@
       }
     },
     "node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mapbox/mapbox-gl-draw": "1.4.1",
     "@mapbox/mapbox-gl-geocoder": "^5.0.2",
     "@mapbox/polyline": "^1.1.1",
+    "@mapbox/web-analytics": "^0.9.0",
     "@placemarkio/tokml": "^0.3.3",
     "@popperjs/core": "^2.11.6",
     "@sentry/browser": "^7.20.0",

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,10 @@ const Sentry = require('@sentry/browser');
 const { BrowserTracing } = require('@sentry/tracing');
 
 window.mbxMetadata = {
-  product: 'GeoJSON.io',
+  product: 'Mapbox GL JS, Maps SDK for Android, Maps SDK for iOS',
   service: 'maps',
   platform: 'web, ios, android',
-  content_type: 'developer tool'
+  content_type: 'playground'
 };
 
 // eslint-disable-next-line no-undef

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ require('../node_modules/mapbox-gl/dist/mapbox-gl.css');
 require('../node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css');
 require('../node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css');
 
+// web-analytics for tracking tool usage
+require('../node_modules/@mapbox/web-analytics/dist/analytics.min.js');
+
 // import css
 require('./css/base.css');
 require('./css/marker.css');
@@ -28,6 +31,18 @@ require('./css/site.css');
 
 const Sentry = require('@sentry/browser');
 const { BrowserTracing } = require('@sentry/tracing');
+
+window.mbxMetadata = {
+  product: 'GeoJSON.io',
+  service: 'maps',
+  platform: 'web, ios, android',
+  content_type: 'developer tool'
+};
+
+// eslint-disable-next-line no-undef
+initializeMapboxAnalytics({
+  marketoMunchkin: false
+});
 
 const ui = require('./ui'),
   map = require('./ui/map'),


### PR DESCRIPTION
This PR adds `@mapbox/web-analytics` to this repo, sets up basic `mbxMetadata` to properly categorize this tool and initializes webAnalytics turning Marketo munchkin off in this instance.  

```
// eslint-disable-next-line no-undef
initializeMapboxAnalytics({
  marketoMunchkin: false
});
```

This works nicely in development as seen in the screenshot below.

<img width="1428" alt="Screenshot 2024-11-06 at 3 54 07 PM" src="https://github.com/user-attachments/assets/d0db687a-d42e-48f2-852c-ff0d18a0bed0">

If approved, I will deploy this update via `npm run deploy`


 

