### PR TITLE
open multiple files at once

### DIFF
--- a/src/ui/file_bar.js
+++ b/src/ui/file_bar.js
@@ -232,19 +232,22 @@ module.exports = function fileBar(context) {
         .select('body')
         .append('input')
         .attr('type', 'file')
+        .attr('multiple', true)
         .style('visibility', 'hidden')
         .style('position', 'absolute')
         .style('height', '0')
         .on('change', function () {
           const files = this.files;
-          if (!(files && files[0])) return;
-          readFile.readAsText(files[0], (err, text) => {
-            readFile.readFile(files[0], text, onImport);
-            if (files[0].path) {
-              context.data.set({
-                path: files[0].path
-              });
-            }
+          if (!(files && files.length)) return;
+          Array.from(files).forEach((file) => {
+            readFile.readAsText(file, (err, text) => {
+              readFile.readFile(file, text, onImport);
+              if (file.path) {
+                context.data.set({
+                  path: file.path
+                });
+              }
+            });
           });
           put.remove();
         });


### PR DESCRIPTION
Hey, thanks for the great tool.

I have the use case that I often need to open multiple files at once. At the moment I need to use the open dialog multiple times to achieve this. With this change I can select multiple files in the dialog which are then opened.

## What's changed
* add multiple attribute to input tag
* iterate over selected files using existing file read behavior

Tested on Ubuntu 24.04 in Firefox and Chromium with up to 10 geojson files and it worked without any problem.