### PR TITLE
Don't escape raster tile layer URL

### DIFF
--- a/src/lib/meta.js
+++ b/src/lib/meta.js
@@ -8,7 +8,8 @@ const escape = require('escape-html'),
   zoomextent = require('../lib/zoomextent');
 
 module.exports.adduserlayer = function (context, _url, _name) {
-  const url = _url,  // Don't escape the URL - it breaks query parameters
+  // Don't escape the URL - it breaks query parameters
+  const url = _url,
     name = escape(_name);
 
   // reset the control if a user-layer was added before


### PR DESCRIPTION
This allows me to enter a URL like:

```
https://us0.nearmap.com/maps/z={z}&x={x}&y={y}&version=2&nml=Vert&client=wmts_integration
&httpauth=false&apikey=foobar
```

I worry, though, the escaping was there for a reason and removing it may break other URLs. I don't have any other URLs to test with, though.