### PR TITLE
Add dynamic asset import & update build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test-browser": "browserify test/index.js | testling",
     "start": "concurrently --kill-others --names live-server rollup \"live-server --ignore=\"$PWD/src/**,$PWD/dist/webfonts/**,$PWD/.git\"\" \"rollup -cw\" \"npx tailwindcss -i $PWD/src/css/tailwind_src.css -o $PWD/dist/css/tailwind_dist.css --watch\"",
     "build": "rimraf dist && npx tailwindcss -i ./src/css/tailwind_src.css -o ./dist/css/tailwind_dist.css && rollup -c",
-    "serve": "live-server"
+    "serve": "cd dist && live-server"
   },
   "lint-staged": {
     "src/**/*.js": "eslint --fix",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,8 @@ export default {
     replace({
       'require.main === module': 'false', // jsonhint export quirk
       // Replace hardcoded dev path with production path in ui/map/clickable_marker.js
-      '../dist/icons': production ? '/icons' : '../dist/icons'    
+      '../dist/icons': production ? '/icons' : '../dist/icons',
+      delimiters: ['', ''] 
     }),
 
     resolve({


### PR DESCRIPTION
This PR allows  updates the `rollup.config.js` file to handle re-writing paths in the `ui/map/clickable_marker.js` in the bundle and updates the package.json `serve` script to run live-server within the built `/dist/` directory.


It addresses an issue noticed after the updated deployment pipeline in #920.  The issue was that relative links of the `ClickableMarker` class failed to retrieve their corresponding SVG's.  

For instance, taking the following (attached) geojson file, the svgs for `rail-metro` would 404 as the component still references a non-existent `/dist` folder.  

This occurs because the new build pipeline changes the root context of the app, serving the contents of the `/dist` folder as the app.  The previous build script, created a orphan branch of the whole repo and pushed that to the `gh-pages` branch.

## Replicate the issue
Download the following stations zip file, upload the extracte geojson file via the 'Open' menu on [geojson.io](https://geojson.io) and you will see the icon SVGs 404 on load. 

[stations.zip](https://github.com/user-attachments/files/20762930/stations.zip)

<img width="1434" alt="Screenshot 2025-06-16 at 2 42 59 PM" src="https://github.com/user-attachments/assets/999787f5-55d3-44b2-807f-2978c539468e" />

## Testing
- Run the local app with `npm start` and test the import of the attached file to ensure the icons display
- Build the local app with `npm run build` and then serve it with `npm run serve` and repeat the same test, ensuring that the icons are present.


