### PR TITLE
Replace classic styles with Standard

### DIFF
--- a/src/ui/layer_switch.js
+++ b/src/ui/layer_switch.js
@@ -21,9 +21,11 @@ module.exports = function (context) {
       // this will likely run before the initial map style is loaded
       // streets is default, but on subsequent runs we must change styles
       if (context.map._loaded) {
-        const { title, style } = d3.select(clicked).datum();
+        const { title, style, config } = d3.select(clicked).datum();
 
-        context.map.setStyle(style);
+        context.map.setStyle(style, {
+          ...(config ? { config } : {})
+        });
 
         context.storage.set('style', title);
 

--- a/src/ui/map/index.js
+++ b/src/ui/map/index.js
@@ -104,11 +104,12 @@ module.exports = function (context, readonly) {
       activeStyle = 'Standard';
     }
 
-    const { style } = styles.find((d) => d.title === activeStyle);
+    const { style, config } = styles.find((d) => d.title === activeStyle);
 
     context.map = new mapboxgl.Map({
       container: 'map',
       style,
+      ...(config ? { config } : {}),
       center: [20, 0],
       zoom: 2,
       projection,
@@ -298,54 +299,25 @@ module.exports = function (context, readonly) {
         context.data.get('mapStyleLoaded') &&
         !context.map.getSource('map-data')
       ) {
-        const { name } = context.map.getStyle();
-
         let color = DEFAULT_DARK_FEATURE_COLOR; // Sets default dark color for lighter base maps
 
-        // Sets a light color for dark base map
-        if (['Mapbox Dark'].includes(name)) {
-          color = DEFAULT_LIGHT_FEATURE_COLOR;
+        // switch to darker feature color for dark base maps
+        let config;
+        const { imports } = context.map.getStyle();
+
+        if (imports && imports.length > 0) {
+          config = context.map.getConfig('basemap');
         }
 
-        // Sets a brighter color for the satellite base map to help with visibility.
-        if (['Mapbox Satellite Streets'].includes(name)) {
-          color = DEFAULT_SATELLITE_FEATURE_COLOR;
-        }
+        if (config) {
+          // check for Standard Dark or Standard Satellite, these two should use lighter feature colors
+          if (config.theme === 'monochrome' && config.lightPreset === 'night') {
+            color = DEFAULT_LIGHT_FEATURE_COLOR;
+          }
 
-        // setFog only on Light and Dark
-        if (['Mapbox Light', 'Mapbox Dark', 'osm'].includes(name)) {
-          context.map.setFog({
-            range: [0.5, 10],
-            color: '#ffffff',
-            'high-color': '#245cdf',
-            'space-color': [
-              'interpolate',
-              ['linear'],
-              ['zoom'],
-              4,
-              '#010b19',
-              7,
-              '#367ab9'
-            ],
-            'horizon-blend': [
-              'interpolate',
-              ['exponential', 1.2],
-              ['zoom'],
-              5,
-              0.02,
-              7,
-              0.08
-            ],
-            'star-intensity': [
-              'interpolate',
-              ['linear'],
-              ['zoom'],
-              5,
-              0.35,
-              6,
-              0
-            ]
-          });
+          if (imports[0].data.name === 'Mapbox Standard Satellite') {
+            color = DEFAULT_SATELLITE_FEATURE_COLOR;
+          }
         }
 
         context.map.addSource('map-data', {
@@ -359,7 +331,8 @@ module.exports = function (context, readonly) {
           source: 'map-data',
           paint: {
             'fill-color': ['coalesce', ['get', 'fill'], color],
-            'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3]
+            'fill-opacity': ['coalesce', ['get', 'fill-opacity'], 0.3],
+            'fill-emissive-strength': 1
           },
           filter: ['==', ['geometry-type'], 'Polygon']
         });
@@ -371,7 +344,8 @@ module.exports = function (context, readonly) {
           paint: {
             'line-color': ['coalesce', ['get', 'stroke'], color],
             'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1],
+            'line-emissive-strength': 1
           },
           filter: ['==', ['geometry-type'], 'Polygon']
         });
@@ -383,7 +357,8 @@ module.exports = function (context, readonly) {
           paint: {
             'line-color': ['coalesce', ['get', 'stroke'], color],
             'line-width': ['coalesce', ['get', 'stroke-width'], 2],
-            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1]
+            'line-opacity': ['coalesce', ['get', 'stroke-opacity'], 1],
+            'line-emissive-strength': 1
           },
           filter: ['==', ['geometry-type'], 'LineString']
         });

--- a/src/ui/map/styles.js
+++ b/src/ui/map/styles.js
@@ -1,23 +1,41 @@
 module.exports = [
   {
     title: 'Standard',
-    style: 'mapbox://styles/mapbox/standard'
+    style: 'mapbox://styles/mapbox/standard',
+    config: {
+      basemap: {
+        show3dObjects: false
+      }
+    }
   },
   {
-    title: 'Satellite Streets',
-    style: 'mapbox://styles/mapbox/satellite-streets-v12'
+    title: 'Standard Satellite',
+    style: 'mapbox://styles/mapbox/standard-satellite'
+  },
+  {
+    title: 'Standard Light',
+    style: 'mapbox://styles/mapbox/standard',
+    config: {
+      basemap: {
+        show3dObjects: false,
+        theme: 'monochrome'
+      }
+    }
+  },
+  {
+    title: 'Standard Dark',
+    style: 'mapbox://styles/mapbox/standard',
+    config: {
+      basemap: {
+        show3dObjects: false,
+        theme: 'monochrome',
+        lightPreset: 'night'
+      }
+    }
   },
   {
     title: 'Outdoors',
     style: 'mapbox://styles/mapbox/outdoors-v12'
-  },
-  {
-    title: 'Light',
-    style: 'mapbox://styles/mapbox/light-v11'
-  },
-  {
-    title: 'Dark',
-    style: 'mapbox://styles/mapbox/dark-v11'
   },
   {
     title: 'OSM',

--- a/src/ui/map/util.js
+++ b/src/ui/map/util.js
@@ -96,11 +96,11 @@ const addMarkers = (geojson, context, writable) => {
 
     // Adjust the feature color for certain styles to help visibility
     switch (activeStyle) {
-      case 'Satellite Streets':
+      case 'Standard Satellite':
         defaultColor = DEFAULT_SATELLITE_FEATURE_COLOR;
         defaultSymbolColor = '#fff';
         break;
-      case 'Dark':
+      case 'Standard Dark':
         defaultColor = DEFAULT_LIGHT_FEATURE_COLOR;
         defaultSymbolColor = DEFAULT_DARK_FEATURE_COLOR;
         break;


### PR DESCRIPTION
This PR replaces the following classic styles:
- `satellite-streets` is replaced with `standard-satellite`
- `light-v11` is replaced with `standard`, with `theme` 'monochrome' 
-  `dark-v11` is replaced with `standard`, with `theme` 'monochrome' and `lightPreset` set to `night`

For all styles that use Mapbox Standard, `show3dObjects` is set to false so that 3d buildings will not interfere with drawn layers.

Logic for changing the color of overlaid geojson feature layers is updated accordingly (Satellite shows green features, dark shows light gray features)

The only remaining classic style is `outdoors-v12`