### PR TITLE
Added g4a tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,17 @@
   ">
   <!-- Add segment tracking for tool usage -->
   <script src="https://docs.mapbox.com/analytics.min.js"></script>
+
+  <!-- G4A Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3K6EEFGNP0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-3K6EEFGNP0');
+  </script>
+
   <style>
     /*
    * http://seclab.stanford.edu/websec/framebusting/framebust.pdf


### PR DESCRIPTION
This PR adds GA4 tracking to geojson.io. This will help us analyze the useage in this tool outside of segment/mode reports (which dont offer the same level of data).
