### PR TITLE
prevent fitBounds on first draw

### DIFF
--- a/next/app/components/map_component.tsx
+++ b/next/app/components/map_component.tsx
@@ -160,11 +160,16 @@ export const MapComponent = memo(function MapComponent({
   // Zoom to initial features once map is ready
   // Used for handling features loaded from sessionStorage
   useEffect(() => {
-    if (!map?.map || hasZoomedRef.current || featureMap.size === 0) return;
+    if (!map?.map || hasZoomedRef.current) return;
 
     const handleLoad = () => {
-      const selectedFeatures = Array.from(featureMap.values());
-      zoomTo(selectedFeatures);
+      // Only zoom if there are features (loaded from sessionStorage)
+      if (featureMap.size > 0) {
+        const selectedFeatures = Array.from(featureMap.values());
+        zoomTo(selectedFeatures);
+      }
+      // Mark as complete even if there were no features to prevent
+      // zooming to newly drawn features
       hasZoomedRef.current = true;
     };
 


### PR DESCRIPTION
Fixes a bug in geojson-io-next where the map would invoke `useZoomTo()` when a user begins drawing a shape. This occurred in the `useEffect` that zooms the map to data loaded from sessionStorage. This PR introduces a bit more logic so the check for features to fit to only happens once after the map loads.