### PR TITLE
disable zoom to all button when there are no features

### DIFF
--- a/next/app/components/panels/feature_editor/feature_editor_folder/header.tsx
+++ b/next/app/components/panels/feature_editor/feature_editor_folder/header.tsx
@@ -77,7 +77,11 @@ export function FeatureEditorFolderHeader({
       </P.Root>
       <Tooltip.Root>
         <Tooltip.Trigger asChild>
-          <Button onClick={handleZoomToAll} size="xs">
+          <Button
+            onClick={handleZoomToAll}
+            size="xs"
+            disabled={featureMap.size === 0}
+          >
             <Crosshair1Icon />
           </Button>
         </Tooltip.Trigger>


### PR DESCRIPTION
Disables the zoom to all button in geojson-io-next when there are no features in `featureMap`