### PR TITLE
fix deckgl circle offset when using standard style

### DIFF
--- a/next/app/lib/pmap/index.ts
+++ b/next/app/lib/pmap/index.ts
@@ -186,6 +186,7 @@ export default class PMap {
     map.on('touchstart', this.onMapTouchStart);
     map.on('touchmove', this.onMapTouchMove);
     map.on('touchend', this.onMapTouchEnd);
+    map.on('style.load', this.onMapStyleLoad);
 
     this.presenceMarkers = new Map();
     this.lastSymbolization = symbolization;
@@ -244,6 +245,11 @@ export default class PMap {
 
   onMapTouchMove = (e: mapboxgl.MapTouchEvent) => {
     this.handlers.current.onMapTouchMove(e);
+  };
+
+  onMapStyleLoad = (event: mapboxgl.MapEvent) => {
+    // disable terrain. If enabled in the style (as in Mapbox Standard style), it causes an alignment bug in the deck.gl overlay
+    (event.target as mapboxgl.Map).setTerrain(null);
   };
 
   onMapDoubleClick = (e: mapboxgl.MapMouseEvent) => {


### PR DESCRIPTION
<img width="401" height="316" alt="image" src="https://github.com/user-attachments/assets/47ca8c11-f0ad-4eb8-b5f9-3a2dc5d8ca6f" />

This PR fixes a bug where the vertices rendered on the map are misaligned with other map features, only when using the Mapbox Standard Style or one of its configured derivatives, only at certain zoom levels (observed around z12.5) and only when the vertices are rendered away from the center of the map.

The vertices are drawn using `MapboxOverlay` from `@deck.gl/mapbox`. On investigation, I discovered the deck viewport zoom was not the same as `map.getZoom()` and that this mismatch was caused by map `terrain` which is enabled by default in the Mapbox Standard Style. The fix is to disable terrain as soon as a style loads using `map.on('style.load')` 