### PR TITLE
Restore the build:next npm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "test-browser": "browserify test/index.js | testling",
     "start": "concurrently --kill-others --names live-server rollup \"live-server --ignore=\"$PWD/src/**,$PWD/dist/**,$PWD/.git\"\" \"rollup -cw\" \"npx tailwindcss -i $PWD/src/css/tailwind_src.css -o $PWD/dist/css/tailwind_dist.css --watch\"",
     "build": "rimraf dist && npx tailwindcss -i ./src/css/tailwind_src.css -o ./dist/css/tailwind_dist.css && rollup -c",
+    "build:next": "cd next && npm ci && npm run build",
     "serve": "cd dist && live-server"
   },
   "overrides": {


### PR DESCRIPTION
- restores the `build:next` npm command which was inadvertently removed in #944
