### PR TITLE
Fix extra coordinate when creating polygons

### DIFF
--- a/next/app/lib/handlers/polygon.ts
+++ b/next/app/lib/handlers/polygon.ts
@@ -231,7 +231,7 @@ export function usePolygonHandlers({
       }
       const feature = wrappedFeature.feature as IFeature<Polygon>;
       const newRing = feature.geometry.coordinates[0].slice();
-      newRing.splice(-2, 1);
+      newRing.splice(-3, 2);
       const finalFeature = replaceCoordinates(feature, [newRing]);
 
       if (!multi) {


### PR DESCRIPTION
This PR fixes a bug when creating polygons and terminating the drawing with a double click.  Previously when closing the polygon with a doubleclick there was an additional duplicate coordinate created.  ie: a 4 sided polygon had 6 coordinates instead of 5.  

This fixes the extra coordinate, properly handling how browsers register clicks.  When double clicking on the Map 3 points are actually created, therefore the `splice()` method needed to remove an additional point.  The `line.ts` handler (which works as expected) already follows this pattern.
