### PR TITLE
cw/simplestyle markers

### DIFF
--- a/next/app/components/panels/feature_editor/feature_editor_style.tsx
+++ b/next/app/components/panels/feature_editor/feature_editor_style.tsx
@@ -2,24 +2,33 @@ import { ColorPopoverField } from 'app/components/color_popover';
 import {
   Button,
   inputClass,
+  PopoverContent2,
   StyledLabelSpan,
   styledCheckbox,
   TextWell
 } from 'app/components/elements';
 import { useAutoSubmit } from 'app/hooks/use_auto_submit';
 import { purple900 } from 'app/lib/constants';
+import { MAKI_ICONS } from 'app/lib/maki';
 import { usePersistence } from 'app/lib/persistence/context';
 import * as d3 from 'd3-color';
 import { Field, Form, Formik, type FormikProps } from 'formik';
 import { useSetAtom } from 'jotai';
 import cloneDeep from 'lodash/cloneDeep';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { Popover as P } from 'radix-ui';
 import { TabOption, tabAtom } from 'state/jotai';
 import type { JsonValue } from 'type-fest';
 import type { GeoJsonProperties, IWrappedFeature } from 'types';
 import { z } from 'zod';
 
-interface FormValues {
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+type MarkerSize = 'small' | 'medium' | 'large';
+
+interface StrokeFillFormValues {
   enableFill: boolean;
   fill: string;
   enableFillOpacity: boolean;
@@ -31,6 +40,18 @@ interface FormValues {
   enableStrokeWidth: boolean;
   'stroke-width': number;
 }
+
+interface MarkerFormValues {
+  enableMarkerColor: boolean;
+  'marker-color': string;
+  'marker-size': MarkerSize;
+  enableMarkerSymbol: boolean;
+  'marker-symbol': string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function getString(set: Set<JsonValue>): string | undefined {
   if (set.size === 1) {
@@ -45,6 +66,32 @@ function getNumber(set: Set<JsonValue>): number | undefined {
     if (typeof val === 'number') return val;
   }
 }
+
+function colorRefine(val: string) {
+  return d3.color(val) !== null;
+}
+
+function AutoSubmit() {
+  useAutoSubmit();
+  return null;
+}
+
+function LiteralStyleNotice() {
+  const setTab = useSetAtom(tabAtom);
+  return (
+    <TextWell>
+      The current map symbolization has literal styles disabled.{' '}
+      <Button onClick={() => setTab(TabOption.Symbolization)} size="xs">
+        Enable literal styles
+      </Button>{' '}
+      for your changes to be seen on the map.
+    </TextWell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Parse helpers
+// ---------------------------------------------------------------------------
 
 export function parseProperties(properties: GeoJsonProperties) {
   const enables = {
@@ -84,37 +131,270 @@ export function parseProperties(properties: GeoJsonProperties) {
     })
   });
 
-  const defaults = zStyles.parse(properties);
+  return { ...zStyles.parse(properties), ...enables };
+}
 
-  const initialValues = {
-    ...defaults,
-    ...enables
+function parseMarkerProperties(
+  properties: GeoJsonProperties
+): MarkerFormValues {
+  const raw = properties || {};
+  const colorRaw = raw['marker-color'];
+  const hasColor = typeof colorRaw === 'string' && d3.color(colorRaw) !== null;
+
+  const symbolRaw = raw['marker-symbol'];
+  const hasSymbol = typeof symbolRaw === 'string' && symbolRaw.length > 0;
+
+  const sizeRaw = raw['marker-size'];
+  const size: MarkerSize =
+    sizeRaw === 'small' || sizeRaw === 'large' ? sizeRaw : 'medium';
+
+  return {
+    enableMarkerColor: hasColor,
+    'marker-color': hasColor ? String(colorRaw) : purple900,
+    'marker-size': size,
+    enableMarkerSymbol: hasSymbol,
+    'marker-symbol': hasSymbol ? String(symbolRaw) : ''
   };
-
-  return initialValues;
 }
 
-/**
- * Used to validate that a string can
- * be parsed as a color.
- */
-function colorRefine(val: string) {
-  const c = d3.color(val);
-  return c !== null;
+// ---------------------------------------------------------------------------
+// Maki icon picker
+// ---------------------------------------------------------------------------
+
+type PickerItem =
+  | { kind: 'char'; name: string }
+  | { kind: 'icon'; name: string; dataUri: string };
+
+// 0-9 then a-z, followed by all maki icons.
+const CHAR_ITEMS: PickerItem[] = [
+  ...'0123456789abcdefghijklmnopqrstuvwxyz'
+    .split('')
+    .map((ch): PickerItem => ({ kind: 'char', name: ch }))
+];
+
+const ALL_PICKER_ITEMS: PickerItem[] = [
+  ...CHAR_ITEMS,
+  ...MAKI_ICONS.map(
+    ({ name, dataUri }): PickerItem => ({ kind: 'icon', name, dataUri })
+  )
+];
+
+function PickerItemButton({
+  item,
+  selected,
+  onSelect,
+  onHover
+}: {
+  item: PickerItem;
+  selected: boolean;
+  onSelect: (name: string) => void;
+  onHover: (name: string | null) => void;
+}) {
+  const base = `w-7 h-7 flex items-center justify-center rounded border transition-colors`;
+  const active = 'bg-blue-500 border-blue-600 text-white';
+  const inactive =
+    'border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700';
+
+  return (
+    <button
+      type="button"
+      title={item.name}
+      onClick={() => onSelect(item.name)}
+      onMouseEnter={() => onHover(item.name)}
+      onMouseLeave={() => onHover(null)}
+      className={`${base} ${selected ? active : inactive}`}
+    >
+      {item.kind === 'char' ? (
+        <span className="font-bold text-xs leading-none">
+          {item.name.toUpperCase()}
+        </span>
+      ) : (
+        <img
+          src={item.dataUri}
+          alt={item.name}
+          className={`w-4 h-4 ${selected ? 'invert' : 'dark:invert'}`}
+        />
+      )}
+    </button>
+  );
 }
 
-const STYLE_PROPS = [
-  'fill',
-  'stroke',
-  'fill-opacity',
-  'stroke-opacity',
-  'stroke-width'
-] as const;
+function MakiIconPicker({
+  value,
+  onChange
+}: {
+  value: string;
+  onChange: (name: string) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const [hovered, setHovered] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
 
-function AutoSubmit() {
-  useAutoSubmit();
-  return null;
+  const filtered = useMemo(() => {
+    if (!search) return ALL_PICKER_ITEMS;
+    const q = search.toLowerCase();
+    return ALL_PICKER_ITEMS.filter((item) => item.name.includes(q));
+  }, [search]);
+
+  const selectedItem = ALL_PICKER_ITEMS.find((i) => i.name === value) ?? null;
+
+  function handleSelect(name: string) {
+    onChange(name);
+    setOpen(false);
+    setSearch('');
+  }
+
+  return (
+    <P.Root open={open} onOpenChange={setOpen}>
+      <P.Trigger asChild>
+        <button
+          type="button"
+          className={
+            inputClass({ _size: 'sm' }) +
+            ' flex items-center gap-x-2 w-full text-left'
+          }
+        >
+          {selectedItem ? (
+            <>
+              {selectedItem.kind === 'char' ? (
+                <span className="w-4 h-4 flex items-center justify-center font-bold text-xs shrink-0">
+                  {selectedItem.name.toUpperCase()}
+                </span>
+              ) : (
+                <img
+                  src={selectedItem.dataUri}
+                  alt={selectedItem.name}
+                  className="w-4 h-4 shrink-0 dark:invert"
+                />
+              )}
+              <span className="font-mono text-xs truncate">
+                {selectedItem.name}
+              </span>
+            </>
+          ) : (
+            <span className="text-gray-400 text-xs">None</span>
+          )}
+        </button>
+      </P.Trigger>
+
+      <PopoverContent2 size="md">
+        <div className="flex flex-col gap-2">
+          <input
+            type="text"
+            placeholder="Search icons…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className={inputClass({ _size: 'sm' }) + ' w-full'}
+            autoFocus
+          />
+
+          <div
+            className="grid overflow-y-auto"
+            style={{
+              gridTemplateColumns: 'repeat(auto-fill, minmax(28px, 1fr))',
+              maxHeight: 220,
+              gap: 2
+            }}
+          >
+            {filtered.map((item) => (
+              <PickerItemButton
+                key={item.name}
+                item={item}
+                selected={item.name === value}
+                onSelect={handleSelect}
+                onHover={setHovered}
+              />
+            ))}
+          </div>
+
+          {/* Hover label */}
+          <div className="h-4 text-xs text-gray-500 font-mono truncate">
+            {hovered ?? '\u00a0'}
+          </div>
+        </div>
+      </PopoverContent2>
+    </P.Root>
+  );
 }
+
+// ---------------------------------------------------------------------------
+// Point marker fields
+// ---------------------------------------------------------------------------
+
+function MarkerFields({ helpers }: { helpers: FormikProps<MarkerFormValues> }) {
+  return (
+    <div className="grid grid-cols-2 gap-y-1 gap-x-2 items-center">
+      {/* Marker color */}
+      <div className="py-1 whitespace-nowrap">
+        <StyledLabelSpan size="xs">Marker color</StyledLabelSpan>
+      </div>
+      <div className="flex items-center gap-x-2">
+        <Field
+          type="checkbox"
+          name="enableMarkerColor"
+          className={styledCheckbox({ variant: 'default' })}
+        />
+        {helpers.values.enableMarkerColor ? (
+          <Field
+            component={ColorPopoverField}
+            name="marker-color"
+            _size="sm"
+            className={inputClass({ _size: 'sm' })}
+          />
+        ) : null}
+      </div>
+
+      {/* Marker size */}
+      <div className="py-1 whitespace-nowrap">
+        <StyledLabelSpan size="xs">Marker size</StyledLabelSpan>
+      </div>
+      <div>
+        <Field
+          as="select"
+          name="marker-size"
+          className={inputClass({ _size: 'sm' }) + ' w-full'}
+        >
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </Field>
+      </div>
+
+      {/* Marker icon */}
+      <div className="py-1 whitespace-nowrap">
+        <StyledLabelSpan size="xs">Marker symbol</StyledLabelSpan>
+      </div>
+      <div className="flex items-center gap-x-2">
+        <Field
+          type="checkbox"
+          name="enableMarkerSymbol"
+          className={styledCheckbox({ variant: 'default' })}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            helpers.setFieldValue('enableMarkerSymbol', e.target.checked);
+            if (!e.target.checked) {
+              helpers.setFieldValue('marker-symbol', '');
+            }
+          }}
+        />
+        {helpers.values.enableMarkerSymbol ? (
+          <div className="flex-1 min-w-0">
+            <MakiIconPicker
+              value={helpers.values['marker-symbol']}
+              onChange={(name) => {
+                helpers.setFieldValue('marker-symbol', name);
+                helpers.submitForm();
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stroke/fill fields
+// ---------------------------------------------------------------------------
 
 function ColorField({
   enableName,
@@ -123,7 +403,7 @@ function ColorField({
 }: {
   enableName: 'enableFill' | 'enableStroke';
   name: 'fill' | 'stroke';
-  helpers: FormikProps<FormValues>;
+  helpers: FormikProps<StrokeFillFormValues>;
 }) {
   return (
     <div className="flex items-center gap-x-2">
@@ -137,42 +417,20 @@ function ColorField({
           component={ColorPopoverField}
           name={name}
           _size="sm"
-          className={inputClass({
-            _size: 'sm'
-          })}
+          className={inputClass({ _size: 'sm' })}
         />
       ) : null}
     </div>
   );
 }
 
-function StyleFields({ helpers }: { helpers: FormikProps<FormValues> }) {
+function StrokeFields({
+  helpers
+}: {
+  helpers: FormikProps<StrokeFillFormValues>;
+}) {
   return (
-    <div className="grid grid-cols-2 gap-y-1 gap-x-2 items-center">
-      <div className="py-1">
-        <StyledLabelSpan size="xs">Fill</StyledLabelSpan>
-      </div>
-      <ColorField name="fill" enableName="enableFill" helpers={helpers} />
-      <div className="py-1 whitespace-nowrap">
-        <StyledLabelSpan size="xs">Fill opacity</StyledLabelSpan>
-      </div>
-      <div className="flex items-center gap-x-2">
-        <Field
-          type="checkbox"
-          name="enableFillOpacity"
-          className={styledCheckbox({ variant: 'default' })}
-        />
-        {helpers.values.enableFillOpacity ? (
-          <Field
-            type="number"
-            name="fill-opacity"
-            step="0.1"
-            min="0"
-            max="1"
-            className={inputClass({ _size: 'sm' })}
-          />
-        ) : null}
-      </div>
+    <>
       <div className="py-1">
         <StyledLabelSpan size="xs">Stroke</StyledLabelSpan>
       </div>
@@ -214,27 +472,104 @@ function StyleFields({ helpers }: { helpers: FormikProps<FormValues> }) {
           />
         ) : null}
       </div>
+    </>
+  );
+}
+
+function AllStyleFields({
+  helpers
+}: {
+  helpers: FormikProps<StrokeFillFormValues>;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-y-1 gap-x-2 items-center">
+      <div className="py-1">
+        <StyledLabelSpan size="xs">Fill</StyledLabelSpan>
+      </div>
+      <ColorField name="fill" enableName="enableFill" helpers={helpers} />
+      <div className="py-1 whitespace-nowrap">
+        <StyledLabelSpan size="xs">Fill opacity</StyledLabelSpan>
+      </div>
+      <div className="flex items-center gap-x-2">
+        <Field
+          type="checkbox"
+          name="enableFillOpacity"
+          className={styledCheckbox({ variant: 'default' })}
+        />
+        {helpers.values.enableFillOpacity ? (
+          <Field
+            type="number"
+            name="fill-opacity"
+            step="0.1"
+            min="0"
+            max="1"
+            className={inputClass({ _size: 'sm' })}
+          />
+        ) : null}
+      </div>
+      <StrokeFields helpers={helpers} />
     </div>
   );
 }
 
-function LiteralStyleNotice() {
-  const setTab = useSetAtom(tabAtom);
+function LineStyleFields({
+  helpers
+}: {
+  helpers: FormikProps<StrokeFillFormValues>;
+}) {
   return (
-    <TextWell>
-      The current map symbolization has literal styles disabled.{' '}
-      <Button
-        onClick={() => {
-          setTab(TabOption.Symbolization);
-        }}
-        size="xs"
-      >
-        Enable literal styles
-      </Button>{' '}
-      for your changes to be seen on the map.
-    </TextWell>
+    <div className="grid grid-cols-2 gap-y-1 gap-x-2 items-center">
+      <StrokeFields helpers={helpers} />
+    </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Stroke/fill form submit helper
+// ---------------------------------------------------------------------------
+
+function buildStrokeFillProps(
+  base: GeoJsonProperties,
+  values: StrokeFillFormValues,
+  includesFill: boolean
+): GeoJsonProperties {
+  const props = cloneDeep(base || {}) as Record<string, unknown>;
+
+  if (includesFill) {
+    if (values.enableFill) {
+      props.fill = values.fill;
+    } else {
+      delete props.fill;
+    }
+    if (values.enableFillOpacity) {
+      props['fill-opacity'] = values['fill-opacity'];
+    } else {
+      delete props['fill-opacity'];
+    }
+  }
+
+  if (values.enableStroke) {
+    props.stroke = values.stroke;
+  } else {
+    delete props.stroke;
+  }
+  if (values.enableStrokeOpacity) {
+    props['stroke-opacity'] = values['stroke-opacity'];
+  } else {
+    delete props['stroke-opacity'];
+  }
+  if (values.enableStrokeWidth) {
+    props['stroke-width'] = values['stroke-width'];
+  } else {
+    delete props['stroke-width'];
+  }
+
+  return props;
+}
+
+// ---------------------------------------------------------------------------
+// FeatureEditorStyle — single feature
+// ---------------------------------------------------------------------------
 
 export function FeatureEditorStyle({
   wrappedFeature
@@ -243,87 +578,109 @@ export function FeatureEditorStyle({
 }) {
   const rep = usePersistence();
   const transact = rep.useTransact();
-  const [meta] = rep.useMetadata();
 
   const properties = wrappedFeature.feature.properties;
+  const geometryType = wrappedFeature.feature.geometry?.type;
+
+  const isPoint = geometryType === 'Point' || geometryType === 'MultiPoint';
+  // Polygons get fill + stroke; lines and everything else get stroke only
+  const isPolygon =
+    geometryType === 'Polygon' || geometryType === 'MultiPolygon';
+
+  // ---- Point ----------------------------------------------------------------
+  if (isPoint) {
+    const initialValues = parseMarkerProperties(properties);
+
+    return (
+      <div className="px-4 py-2">
+        <Formik<MarkerFormValues>
+          onSubmit={(values) => {
+            const props = cloneDeep(properties || {}) as GeoJsonProperties;
+
+            if (values.enableMarkerColor) {
+              props!['marker-color'] = values['marker-color'];
+            } else {
+              delete props!['marker-color'];
+            }
+
+            props!['marker-size'] = values['marker-size'];
+
+            if (values.enableMarkerSymbol && values['marker-symbol']) {
+              props!['marker-symbol'] = values['marker-symbol'];
+            } else {
+              delete props!['marker-symbol'];
+            }
+
+            return transact({
+              track: 'feature-update-style',
+              putFeatures: [
+                {
+                  ...wrappedFeature,
+                  feature: { ...wrappedFeature.feature, properties: props }
+                }
+              ]
+            });
+          }}
+          initialValues={initialValues}
+        >
+          {(helpers) => (
+            <Form>
+              <AutoSubmit />
+              <MarkerFields helpers={helpers} />
+            </Form>
+          )}
+        </Formik>
+      </div>
+    );
+  }
+
+  // ---- Line / Polygon -------------------------------------------------------
   const initialValues = parseProperties(properties);
+  const includesFill = isPolygon;
 
   return (
     <div className="px-4 py-2">
-      <Formik<FormValues>
+      <Formik<StrokeFillFormValues>
         onSubmit={(values) => {
-          const properties: GeoJsonProperties = cloneDeep(
-            wrappedFeature.feature.properties || {}
-          );
-
-          if (values.enableFill) {
-            properties.fill = values.fill;
-          } else {
-            delete properties.fill;
-          }
-
-          if (values.enableFillOpacity) {
-            properties['fill-opacity'] = values['fill-opacity'];
-          } else {
-            delete properties['fill-opacity'];
-          }
-
-          if (values.enableStroke) {
-            properties.stroke = values.stroke;
-          } else {
-            delete properties.stroke;
-          }
-
-          if (values.enableStrokeOpacity) {
-            properties['stroke-opacity'] = values['stroke-opacity'];
-          } else {
-            delete properties['stroke-opacity'];
-          }
-
-          if (values.enableStrokeWidth) {
-            properties['stroke-width'] = values['stroke-width'];
-          } else {
-            delete properties['stroke-width'];
-          }
-
+          const props = buildStrokeFillProps(properties, values, includesFill);
           return transact({
             track: 'feature-update-style',
             putFeatures: [
               {
                 ...wrappedFeature,
-                feature: {
-                  ...wrappedFeature.feature,
-                  properties
-                }
+                feature: { ...wrappedFeature.feature, properties: props }
               }
             ]
           });
         }}
         initialValues={initialValues}
       >
-        {(helpers) => {
-          return (
-            <Form>
-              <AutoSubmit />
-              <StyleFields helpers={helpers} />
-              {/*<AutoReset properties={properties} />*/}
-            </Form>
-          );
-        }}
+        {(helpers) => (
+          <Form>
+            <AutoSubmit />
+            {isPolygon ? (
+              <AllStyleFields helpers={helpers} />
+            ) : (
+              <LineStyleFields helpers={helpers} />
+            )}
+          </Form>
+        )}
       </Formik>
     </div>
   );
 }
 
-// function AutoReset({ properties }: { properties: GeoJsonProperties }) {
-//   const context = useFormikContext();
-//
-//   // useEffect(() => {
-//   //   context.resetForm();
-//   // }, [context, properties]);
-//
-//   return null;
-// }
+// ---------------------------------------------------------------------------
+// FeatureEditorStyleMulti — multiple features selected
+// ---------------------------------------------------------------------------
+
+const STROKE_FILL_PROPS = [
+  'fill',
+  'stroke',
+  'fill-opacity',
+  'stroke-opacity',
+  'stroke-width'
+] as const;
 
 export function FeatureEditorStyleMulti({
   wrappedFeatures
@@ -335,7 +692,10 @@ export function FeatureEditorStyleMulti({
   const [meta] = rep.useMetadata();
 
   const uniformValues = useMemo(() => {
-    const allValues: Record<typeof STYLE_PROPS[number], Set<JsonValue>> = {
+    const allValues: Record<
+      (typeof STROKE_FILL_PROPS)[number],
+      Set<JsonValue>
+    > = {
       fill: new Set(),
       stroke: new Set(),
       'fill-opacity': new Set(),
@@ -346,21 +706,18 @@ export function FeatureEditorStyleMulti({
     for (const { feature } of wrappedFeatures) {
       const { properties } = feature;
       if (!properties) continue;
-      for (const key of STYLE_PROPS) {
-        const val = properties[key];
-        allValues[key].add(val);
+      for (const key of STROKE_FILL_PROPS) {
+        allValues[key].add(properties[key]);
       }
     }
 
-    const uniformValues = {
+    return {
       fill: getString(allValues.fill),
       'fill-opacity': getNumber(allValues['fill-opacity']),
       stroke: getString(allValues.stroke),
       'stroke-opacity': getNumber(allValues['stroke-opacity']),
       'stroke-width': getNumber(allValues['stroke-width'])
     };
-
-    return uniformValues;
   }, [wrappedFeatures]);
 
   const initialValues = parseProperties(uniformValues);
@@ -370,55 +727,31 @@ export function FeatureEditorStyleMulti({
       {meta.symbolization?.simplestyle === false ? (
         <LiteralStyleNotice />
       ) : null}
-      <Formik<FormValues>
+      <Formik<StrokeFillFormValues>
         onSubmit={(values) => {
           return transact({
             track: 'feature-update-style-multi',
             putFeatures: wrappedFeatures.map((wrappedFeature) => {
-              const properties: GeoJsonProperties = cloneDeep(
-                wrappedFeature.feature.properties || {}
+              const props = buildStrokeFillProps(
+                wrappedFeature.feature.properties,
+                values,
+                true
               );
-
-              if (values.enableFill) {
-                properties.fill = values.fill;
-              }
-
-              if (values.enableFillOpacity) {
-                properties['fill-opacity'] = values['fill-opacity'];
-              }
-
-              if (values.enableStroke) {
-                properties.stroke = values.stroke;
-              }
-
-              if (values.enableStrokeOpacity) {
-                properties['stroke-opacity'] = values['stroke-opacity'];
-              }
-
-              if (values.enableStrokeWidth) {
-                properties['stroke-width'] = values['stroke-width'];
-              }
-
               return {
                 ...wrappedFeature,
-                feature: {
-                  ...wrappedFeature.feature,
-                  properties
-                }
+                feature: { ...wrappedFeature.feature, properties: props }
               };
             })
           });
         }}
         initialValues={initialValues}
       >
-        {(helpers) => {
-          return (
-            <Form>
-              <AutoSubmit />
-              <StyleFields helpers={helpers} />
-            </Form>
-          );
-        }}
+        {(helpers) => (
+          <Form>
+            <AutoSubmit />
+            <AllStyleFields helpers={helpers} />
+          </Form>
+        )}
       </Formik>
     </div>
   );

--- a/next/app/components/panels/feature_editor/feature_editor_style.tsx
+++ b/next/app/components/panels/feature_editor/feature_editor_style.tsx
@@ -44,6 +44,7 @@ interface StrokeFillFormValues {
 interface MarkerFormValues {
   enableMarkerColor: boolean;
   'marker-color': string;
+  enableMarkerSize: boolean;
   'marker-size': MarkerSize;
   enableMarkerSymbol: boolean;
   'marker-symbol': string;
@@ -145,12 +146,15 @@ function parseMarkerProperties(
   const hasSymbol = typeof symbolRaw === 'string' && symbolRaw.length > 0;
 
   const sizeRaw = raw['marker-size'];
+  const hasSize =
+    sizeRaw === 'small' || sizeRaw === 'medium' || sizeRaw === 'large';
   const size: MarkerSize =
     sizeRaw === 'small' || sizeRaw === 'large' ? sizeRaw : 'medium';
 
   return {
     enableMarkerColor: hasColor,
     'marker-color': hasColor ? String(colorRaw) : purple900,
+    enableMarkerSize: hasSize,
     'marker-size': size,
     enableMarkerSymbol: hasSymbol,
     'marker-symbol': hasSymbol ? String(symbolRaw) : ''
@@ -348,16 +352,23 @@ function MarkerFields({ helpers }: { helpers: FormikProps<MarkerFormValues> }) {
       <div className="py-1 whitespace-nowrap">
         <StyledLabelSpan size="xs">Marker size</StyledLabelSpan>
       </div>
-      <div>
+      <div className="flex items-center gap-x-2">
         <Field
-          as="select"
-          name="marker-size"
-          className={inputClass({ _size: 'sm' }) + ' w-full'}
-        >
-          <option value="small">Small</option>
-          <option value="medium">Medium</option>
-          <option value="large">Large</option>
-        </Field>
+          type="checkbox"
+          name="enableMarkerSize"
+          className={styledCheckbox({ variant: 'default' })}
+        />
+        {helpers.values.enableMarkerSize ? (
+          <Field
+            as="select"
+            name="marker-size"
+            className={inputClass({ _size: 'sm' }) + ' w-full'}
+          >
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+          </Field>
+        ) : null}
       </div>
 
       {/* Marker icon */}
@@ -603,7 +614,11 @@ export function FeatureEditorStyle({
               delete props!['marker-color'];
             }
 
-            props!['marker-size'] = values['marker-size'];
+            if (values.enableMarkerSize) {
+              props!['marker-size'] = values['marker-size'];
+            } else {
+              delete props!['marker-size'];
+            }
 
             if (values.enableMarkerSymbol && values['marker-symbol']) {
               props!['marker-symbol'] = values['marker-symbol'];

--- a/next/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
+++ b/next/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
@@ -204,6 +204,128 @@ exports[`loadAndAugmentStyle 1`] = `
       "source": "features",
       "type": "circle",
     },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point",
+        ],
+        [
+          "has",
+          "marker-symbol",
+        ],
+      ],
+      "id": "features-marker-symbol",
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+        "icon-image": [
+          "let",
+          "sym",
+          [
+            "coalesce",
+            [
+              "get",
+              "marker-symbol",
+            ],
+            "",
+          ],
+          [
+            "case",
+            [
+              ">",
+              [
+                "length",
+                [
+                  "var",
+                  "sym",
+                ],
+              ],
+              1,
+            ],
+            [
+              "var",
+              "sym",
+            ],
+            "",
+          ],
+        ],
+        "icon-size": [
+          "match",
+          [
+            "get",
+            "marker-size",
+          ],
+          "small",
+          0.4,
+          "large",
+          1.2,
+          0.8,
+        ],
+        "text-allow-overlap": true,
+        "text-field": [
+          "let",
+          "sym",
+          [
+            "coalesce",
+            [
+              "get",
+              "marker-symbol",
+            ],
+            "",
+          ],
+          [
+            "case",
+            [
+              "==",
+              [
+                "length",
+                [
+                  "var",
+                  "sym",
+                ],
+              ],
+              1,
+            ],
+            [
+              "upcase",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            "",
+          ],
+        ],
+        "text-font": [
+          "DIN Offc Pro Bold",
+          "Arial Unicode MS Bold",
+        ],
+        "text-ignore-placement": true,
+        "text-size": [
+          "match",
+          [
+            "get",
+            "marker-size",
+          ],
+          "small",
+          8,
+          "large",
+          18,
+          13,
+        ],
+      },
+      "paint": {
+        "icon-color": "white",
+        "icon-emissive-strength": 1,
+        "text-color": "white",
+        "text-emissive-strength": 1,
+      },
+      "source": "features",
+      "type": "symbol",
+    },
   ],
   "name": "Empty",
   "sources": {
@@ -608,6 +730,128 @@ exports[`makeLayers > categorical 2`] = `
     "source": "features",
     "type": "circle",
   },
+  {
+    "filter": [
+      "all",
+      [
+        "==",
+        "$type",
+        "Point",
+      ],
+      [
+        "has",
+        "marker-symbol",
+      ],
+    ],
+    "id": "features-marker-symbol",
+    "layout": {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            ">",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "var",
+            "sym",
+          ],
+          "",
+        ],
+      ],
+      "icon-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        0.4,
+        "large",
+        1.2,
+        0.8,
+      ],
+      "text-allow-overlap": true,
+      "text-field": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            "==",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "upcase",
+            [
+              "var",
+              "sym",
+            ],
+          ],
+          "",
+        ],
+      ],
+      "text-font": [
+        "DIN Offc Pro Bold",
+        "Arial Unicode MS Bold",
+      ],
+      "text-ignore-placement": true,
+      "text-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        8,
+        "large",
+        18,
+        13,
+      ],
+    },
+    "paint": {
+      "icon-color": "white",
+      "icon-emissive-strength": 1,
+      "text-color": "white",
+      "text-emissive-strength": 1,
+    },
+    "source": "features",
+    "type": "symbol",
+  },
 ]
 `;
 
@@ -704,8 +948,34 @@ exports[`makeLayers > categorical with override 1`] = `
       "state"
     ],
     "selected",
-    6,
-    4
+    [
+      "+",
+      [
+        "match",
+        [
+          "get",
+          "marker-size"
+        ],
+        "medium",
+        8,
+        "large",
+        12,
+        4
+      ],
+      2
+    ],
+    [
+      "match",
+      [
+        "get",
+        "marker-size"
+      ],
+      "medium",
+      8,
+      "large",
+      12,
+      4
+    ]
   ],
   "circle-opacity": 1,
   "circle-color": [
@@ -720,7 +990,7 @@ exports[`makeLayers > categorical with override 1`] = `
       "coalesce",
       [
         "get",
-        "stroke"
+        "marker-color"
       ],
       [
         "match",
@@ -975,6 +1245,128 @@ exports[`makeLayers > none 1`] = `
     },
     "source": "features",
     "type": "circle",
+  },
+  {
+    "filter": [
+      "all",
+      [
+        "==",
+        "$type",
+        "Point",
+      ],
+      [
+        "has",
+        "marker-symbol",
+      ],
+    ],
+    "id": "features-marker-symbol",
+    "layout": {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            ">",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "var",
+            "sym",
+          ],
+          "",
+        ],
+      ],
+      "icon-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        0.4,
+        "large",
+        1.2,
+        0.8,
+      ],
+      "text-allow-overlap": true,
+      "text-field": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            "==",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "upcase",
+            [
+              "var",
+              "sym",
+            ],
+          ],
+          "",
+        ],
+      ],
+      "text-font": [
+        "DIN Offc Pro Bold",
+        "Arial Unicode MS Bold",
+      ],
+      "text-ignore-placement": true,
+      "text-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        8,
+        "large",
+        18,
+        13,
+      ],
+    },
+    "paint": {
+      "icon-color": "white",
+      "icon-emissive-strength": 1,
+      "text-color": "white",
+      "text-emissive-strength": 1,
+    },
+    "source": "features",
+    "type": "symbol",
   },
 ]
 `;
@@ -1330,6 +1722,128 @@ exports[`makeLayers > ramp 1`] = `
     },
     "source": "features",
     "type": "circle",
+  },
+  {
+    "filter": [
+      "all",
+      [
+        "==",
+        "$type",
+        "Point",
+      ],
+      [
+        "has",
+        "marker-symbol",
+      ],
+    ],
+    "id": "features-marker-symbol",
+    "layout": {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            ">",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "var",
+            "sym",
+          ],
+          "",
+        ],
+      ],
+      "icon-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        0.4,
+        "large",
+        1.2,
+        0.8,
+      ],
+      "text-allow-overlap": true,
+      "text-field": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            "==",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "upcase",
+            [
+              "var",
+              "sym",
+            ],
+          ],
+          "",
+        ],
+      ],
+      "text-font": [
+        "DIN Offc Pro Bold",
+        "Arial Unicode MS Bold",
+      ],
+      "text-ignore-placement": true,
+      "text-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        8,
+        "large",
+        18,
+        13,
+      ],
+    },
+    "paint": {
+      "icon-color": "white",
+      "icon-emissive-strength": 1,
+      "text-color": "white",
+      "text-emissive-strength": 1,
+    },
+    "source": "features",
+    "type": "symbol",
   },
 ]
 `;
@@ -1730,6 +2244,128 @@ exports[`makeLayers > with preview property 1`] = `
     },
     "source": "features",
     "type": "circle",
+  },
+  {
+    "filter": [
+      "all",
+      [
+        "==",
+        "$type",
+        "Point",
+      ],
+      [
+        "has",
+        "marker-symbol",
+      ],
+    ],
+    "id": "features-marker-symbol",
+    "layout": {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            ">",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "var",
+            "sym",
+          ],
+          "",
+        ],
+      ],
+      "icon-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        0.4,
+        "large",
+        1.2,
+        0.8,
+      ],
+      "text-allow-overlap": true,
+      "text-field": [
+        "let",
+        "sym",
+        [
+          "coalesce",
+          [
+            "get",
+            "marker-symbol",
+          ],
+          "",
+        ],
+        [
+          "case",
+          [
+            "==",
+            [
+              "length",
+              [
+                "var",
+                "sym",
+              ],
+            ],
+            1,
+          ],
+          [
+            "upcase",
+            [
+              "var",
+              "sym",
+            ],
+          ],
+          "",
+        ],
+      ],
+      "text-font": [
+        "DIN Offc Pro Bold",
+        "Arial Unicode MS Bold",
+      ],
+      "text-ignore-placement": true,
+      "text-size": [
+        "match",
+        [
+          "get",
+          "marker-size",
+        ],
+        "small",
+        8,
+        "large",
+        18,
+        13,
+      ],
+    },
+    "paint": {
+      "icon-color": "white",
+      "icon-emissive-strength": 1,
+      "text-color": "white",
+      "text-emissive-strength": 1,
+    },
+    "source": "features",
+    "type": "symbol",
   },
   {
     "filter": [

--- a/next/app/lib/constants.ts
+++ b/next/app/lib/constants.ts
@@ -170,7 +170,11 @@ export const SIMPLESTYLE_PROPERTIES = [
   'stroke-width',
   'stroke-opacity',
   'fill',
-  'fill-opacity'
+  'fill-opacity',
+  'marker-color',
+  'marker-size',
+  'marker-symbol',
+  'marker-icon'
 ] as const;
 
 const geojsonTypes: GeoJSONTypeList = [
@@ -229,7 +233,7 @@ export const FILE_LIMIT_MB = Infinity;
 export const FILE_LIMIT_BYTES = FILE_LIMIT_MB * MB_TO_BYTES;
 
 export const SCALE_UNITS = ['imperial', 'metric', 'nautical'] as const;
-export type ScaleUnit = typeof SCALE_UNITS[number];
+export type ScaleUnit = (typeof SCALE_UNITS)[number];
 export const zScaleUnit = z.enum(SCALE_UNITS);
 
 export const WHITE: RGBA = [255, 255, 255, 255];

--- a/next/app/lib/constants.ts
+++ b/next/app/lib/constants.ts
@@ -173,8 +173,7 @@ export const SIMPLESTYLE_PROPERTIES = [
   'fill-opacity',
   'marker-color',
   'marker-size',
-  'marker-symbol',
-  'marker-icon'
+  'marker-symbol'
 ] as const;
 
 const geojsonTypes: GeoJSONTypeList = [

--- a/next/app/lib/load_and_augment_style.test.ts
+++ b/next/app/lib/load_and_augment_style.test.ts
@@ -80,6 +80,7 @@ describe('makeLayers', () => {
 
     const emptyStyle: mapboxgl.Style = {
       version: 8,
+      glyphs: 'https://foo.com/foo{fontstack}/{range}',
       sources: {},
       layers: []
     };
@@ -108,6 +109,7 @@ describe('makeLayers', () => {
     const layers = makeLayers(inputs);
     const emptyStyle: mapboxgl.Style = {
       version: 8,
+      glyphs: 'https://foo.com/foo{fontstack}/{range}',
       sources: {},
       layers: []
     };

--- a/next/app/lib/load_and_augment_style.ts
+++ b/next/app/lib/load_and_augment_style.ts
@@ -30,6 +30,7 @@ const EPHEMERAL_FILL_LAYER_NAME = 'ephemeral-fill';
 
 const FEATURES_POINT_HALO_LAYER_NAME = 'features-symbol-halo';
 const FEATURES_POINT_LAYER_NAME = 'features-symbol';
+const FEATURES_MARKER_SYMBOL_LAYER_NAME = 'features-marker-symbol';
 const FEATURES_POINT_LABEL_LAYER_NAME = 'features-point-label';
 const FEATURES_FILL_LABEL_LAYER_NAME = 'features-fill-label';
 const FEATURES_LINE_LABEL_LAYER_NAME = 'features-line-label';
@@ -172,6 +173,70 @@ export function makeLayers({
       filter: CONTENT_LAYER_FILTERS[FEATURES_POINT_LAYER_NAME],
       paint: CIRCLE_PAINT(symbolization)
     },
+
+    // Simplestyle marker-symbol / marker-icon: maki icons or single char text.
+    // Supports both `marker-symbol` (simplestyle spec) and `marker-icon`
+    // (geojson.io legacy convention).
+    {
+      id: FEATURES_MARKER_SYMBOL_LAYER_NAME,
+      type: 'symbol',
+      source: FEATURES_SOURCE_NAME,
+      filter: [
+        'all',
+        ['==', '$type', 'Point'],
+        ['any', ['has', 'marker-symbol'], ['has', 'marker-icon']]
+      ],
+      layout: {
+        // Resolve the icon value from either property.
+        'icon-image': [
+          'let',
+          'sym',
+          ['coalesce', ['get', 'marker-symbol'], ['get', 'marker-icon'], ''],
+          ['case', ['>', ['length', ['var', 'sym']], 1], ['var', 'sym'], '']
+        ],
+        'icon-size': [
+          'match',
+          ['get', 'marker-size'],
+          'small',
+          0.4,
+          'large',
+          1.2,
+          0.8
+        ],
+        'icon-allow-overlap': true,
+        'icon-ignore-placement': true,
+        // Single-char symbols rendered as text.
+        'text-field': [
+          'let',
+          'sym',
+          ['coalesce', ['get', 'marker-symbol'], ['get', 'marker-icon'], ''],
+          [
+            'case',
+            ['==', ['length', ['var', 'sym']], 1],
+            ['upcase', ['var', 'sym']],
+            ''
+          ]
+        ],
+        'text-size': [
+          'match',
+          ['get', 'marker-size'],
+          'small',
+          8,
+          'large',
+          18,
+          13
+        ],
+        'text-font': ['DIN Offc Pro Bold', 'Arial Unicode MS Bold'],
+        'text-allow-overlap': true,
+        'text-ignore-placement': true
+      } as mapboxgl.SymbolLayout,
+      paint: {
+        'icon-color': 'white',
+        'text-color': 'white',
+        'icon-emissive-strength': 1,
+        'text-emissive-strength': 1
+      } as mapboxgl.SymbolPaint
+    } as mapboxgl.AnyLayer,
 
     ...(typeof previewProperty === 'string'
       ? [
@@ -316,10 +381,78 @@ function LABEL_LAYOUT(
   return paint;
 }
 
+/**
+ * Maps simplestyle marker-size (small/medium/large) to a pixel radius.
+ * Defaults to small (4px) when the property is absent.
+ */
+function markerSizeRadius(): mapboxgl.Expression {
+  // small  → 4 px  (matches the normal non-simplestyle marker appearance)
+  // medium → 8 px (slightly larger)
+  // large  → 12 px (clearly distinct)
+  return ['match', ['get', 'marker-size'], 'medium', 8, 'large', 12, 4];
+}
+
 export function CIRCLE_PAINT(
   symbolization: ISymbolization,
   halo = false
 ): mapboxgl.CirclePaint {
+  if (symbolization.simplestyle) {
+    // marker-color overrides the symbolization color when present.
+    const markerColor: mapboxgl.Expression = [
+      'coalesce',
+      ['get', 'marker-color'],
+      asColorExpressionInner({ symbolization })
+    ];
+
+    if (halo) {
+      return {
+        'circle-color': [
+          'match',
+          ['feature-state', 'state'],
+          'selected',
+          'white',
+          markerColor
+        ],
+        // Halo is always 2 px larger than the main circle.
+        'circle-radius': [
+          'match',
+          ['feature-state', 'state'],
+          'selected',
+          ['+', markerSizeRadius(), 4],
+          ['+', markerSizeRadius(), 2]
+        ],
+        'circle-emissive-strength': 1
+      };
+    }
+    return {
+      'circle-stroke-color': [
+        'match',
+        ['feature-state', 'state'],
+        'selected',
+        LINE_COLORS_SELECTED,
+        'white'
+      ],
+      'circle-stroke-width': 1,
+      'circle-radius': [
+        'match',
+        ['feature-state', 'state'],
+        'selected',
+        ['+', markerSizeRadius(), 2],
+        markerSizeRadius()
+      ],
+      'circle-opacity': 1,
+      'circle-color': [
+        'match',
+        ['feature-state', 'state'],
+        'selected',
+        'white',
+        markerColor
+      ],
+      'circle-emissive-strength': 1
+    };
+  }
+
+  // Non-simplestyle: original fixed-size behaviour.
   const r = halo ? 2 : 0;
   if (halo) {
     return {

--- a/next/app/lib/load_and_augment_style.ts
+++ b/next/app/lib/load_and_augment_style.ts
@@ -175,23 +175,19 @@ export function makeLayers({
     },
 
     // Simplestyle marker-symbol / marker-icon: maki icons or single char text.
-    // Supports both `marker-symbol` (simplestyle spec) and `marker-icon`
+    // Supports both `marker-symbol` (simplestyle spec)
     // (geojson.io legacy convention).
     {
       id: FEATURES_MARKER_SYMBOL_LAYER_NAME,
       type: 'symbol',
       source: FEATURES_SOURCE_NAME,
-      filter: [
-        'all',
-        ['==', '$type', 'Point'],
-        ['any', ['has', 'marker-symbol'], ['has', 'marker-icon']]
-      ],
+      filter: ['all', ['==', '$type', 'Point'], ['has', 'marker-symbol']],
       layout: {
         // Resolve the icon value from either property.
         'icon-image': [
           'let',
           'sym',
-          ['coalesce', ['get', 'marker-symbol'], ['get', 'marker-icon'], ''],
+          ['coalesce', ['get', 'marker-symbol'], ''],
           ['case', ['>', ['length', ['var', 'sym']], 1], ['var', 'sym'], '']
         ],
         'icon-size': [
@@ -209,7 +205,7 @@ export function makeLayers({
         'text-field': [
           'let',
           'sym',
-          ['coalesce', ['get', 'marker-symbol'], ['get', 'marker-icon'], ''],
+          ['coalesce', ['get', 'marker-symbol'], ''],
           [
             'case',
             ['==', ['length', ['var', 'sym']], 1],

--- a/next/app/lib/maki.ts
+++ b/next/app/lib/maki.ts
@@ -1,0 +1,29 @@
+import { svgArray } from '@mapbox/maki';
+import mapboxgl from 'mapbox-gl';
+
+/**
+ * Load all maki icons into a Mapbox GL map as SDF images so they can be
+ * recolored via the icon-color paint property.
+ */
+export async function loadMakiIcons(map: mapboxgl.Map): Promise<void> {
+  await Promise.all(
+    (svgArray as string[]).map((svg) => {
+      const name = svg.match(/id="([^"]+)"/)?.[1];
+      if (!name) return Promise.resolve();
+
+      const url = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+
+      return new Promise<void>((resolve) => {
+        const img = new Image(15, 15);
+        img.onload = () => {
+          if (!map.hasImage(name)) {
+            map.addImage(name, img, { sdf: true });
+          }
+          resolve();
+        };
+        img.onerror = () => resolve();
+        img.src = url;
+      });
+    })
+  );
+}

--- a/next/app/lib/maki.ts
+++ b/next/app/lib/maki.ts
@@ -1,6 +1,26 @@
 import { svgArray } from '@mapbox/maki';
 import mapboxgl from 'mapbox-gl';
 
+export interface MakiIcon {
+  name: string;
+  /** data URI usable as <img src> */
+  dataUri: string;
+}
+
+/**
+ * All maki icons with their names and data URIs for UI rendering.
+ */
+export const MAKI_ICONS: MakiIcon[] = (svgArray as string[]).flatMap((svg) => {
+  const name = svg.match(/id="([^"]+)"/)?.[1];
+  if (!name) return [];
+  return [
+    {
+      name,
+      dataUri: `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+    }
+  ];
+});
+
 /**
  * Load all maki icons into a Mapbox GL map as SDF images so they can be
  * recolored via the icon-color paint property.

--- a/next/app/lib/pmap/index.ts
+++ b/next/app/lib/pmap/index.ts
@@ -1,6 +1,7 @@
 import { PolygonLayer, ScatterplotLayer } from '@deck.gl/layers';
 import { MapboxOverlay } from '@deck.gl/mapbox';
 import { colorFromPresence } from 'app/lib/color';
+import { loadMakiIcons } from 'app/lib/maki';
 import {
   CURSOR_DEFAULT,
   DECK_LASSO_ID,
@@ -248,8 +249,11 @@ export default class PMap {
   };
 
   onMapStyleLoad = (event: mapboxgl.MapEvent) => {
+    const map = event.target as mapboxgl.Map;
     // disable terrain. If enabled in the style (as in Mapbox Standard style), it causes an alignment bug in the deck.gl overlay
-    (event.target as mapboxgl.Map).setTerrain(null);
+    map.setTerrain(null);
+    // Load maki icons as SDF images so marker-symbol icons can be recolored via icon-color.
+    void loadMakiIcons(map);
   };
 
   onMapDoubleClick = (e: mapboxgl.MapMouseEvent) => {

--- a/next/types/mapbox__maki.d.ts
+++ b/next/types/mapbox__maki.d.ts
@@ -1,0 +1,4 @@
+declare module '@mapbox/maki' {
+  /** Array of SVG strings for all maki icons. */
+  export const svgArray: string[];
+}


### PR DESCRIPTION
Adds support for `simplestyle-spec` properties for point features in geojson.io/next. Covers both rendering of simplestyle spec point properties and adds controls for choosing them in the **Styles** menu in the **Feature Editor**

<img width="1209" height="769" alt="image" src="https://github.com/user-attachments/assets/b120881e-33da-4d30-a76b-a2800fadf9c0" />

## `marker-size` 

`small` renders a marker at 4px radius, the same as default markers in geojson.io/next.
`medium` and `large` have radius 8px and 12px respectively.

## `marker-symbol`

## Styles Panel

The styles panel is update to only show relevant simplestyle-spec inputs for the selected feature's geometry type, (point features do not need `fill-` or `stroke-` properties, so they are not shown, etc). 

`marker-color` shows the color picker
`marker-size` shows a dropdown with the three valid values
`marker-symbol` shows a custom popover where users can click a maki icon or a-z/0-9 character, or search by id. 

<img width="826" height="524" alt="image" src="https://github.com/user-attachments/assets/1d0f518f-b7a2-4c22-9887-eb6a1a516a6e" />



