### PR TITLE
Add custom raster layers in geojson.io/next

### DIFF
--- a/next/app/components/dialogs.tsx
+++ b/next/app/components/dialogs.tsx
@@ -6,6 +6,7 @@ import { ExportDialog } from 'app/components/dialogs/export';
 import { ImportDialog } from 'app/components/dialogs/import';
 import { ImportNotesDialog } from 'app/components/dialogs/import_notes';
 import { ImportURLDialog } from 'app/components/dialogs/import_url';
+import { RasterLayerDialog } from 'app/components/dialogs/raster_layer';
 import { QuickswitcherDialog } from 'app/components/search/quickswitcher';
 import SimplifyDialog from 'app/components/dialogs/simplify';
 import AboutModal from 'app/components/about_modal';
@@ -60,6 +61,9 @@ export const Dialogs = memo(function Dialogs() {
       <BufferDialog onClose={onClose} modal={modal} />
     ))
     .with({ type: 'from_url' }, () => <ImportURLDialog onClose={onClose} />)
+    .with({ type: 'raster_layer' }, (modal) => (
+      <RasterLayerDialog modal={modal} onClose={onClose} />
+    ))
     .with({ type: 'about' }, () => {
       extraWide = true;
       return <AboutModal open={true} />;

--- a/next/app/components/dialogs/raster_layer.tsx
+++ b/next/app/components/dialogs/raster_layer.tsx
@@ -2,11 +2,9 @@ import { LayersIcon } from '@radix-ui/react-icons';
 import { DialogHeader } from 'app/components/dialog';
 import SimpleDialogActions from 'app/components/dialogs/simple_dialog_actions';
 import { TextWell } from 'app/components/elements';
-import { InlineError } from 'app/components/inline_error';
 import { LabeledTextField } from 'app/core/components/LabeledTextField';
 import { Form, Formik } from 'formik';
 import { useAtom } from 'jotai';
-import { useState } from 'react';
 import { customRasterLayersAtom } from 'state/jotai';
 import type { DialogStateRasterLayer } from 'state/dialog_state';
 import { toast } from 'react-hot-toast';
@@ -32,7 +30,6 @@ export function RasterLayerDialog({
   const [customRasterLayers, setCustomRasterLayers] = useAtom(
     customRasterLayersAtom
   );
-  const [formError, setFormError] = useState<string | null>(null);
 
   const isEditing = !!modal.editingLayer;
   const initialValues: RasterLayerFormValues = isEditing
@@ -52,28 +49,23 @@ export function RasterLayerDialog({
         titleIcon={LayersIcon}
       />
       <Formik<RasterLayerFormValues>
+        validate={(values) => {
+          const errors: Partial<Record<keyof RasterLayerFormValues, string>> =
+            {};
+
+          if (!values.name.trim()) {
+            errors.name = 'Layer name is required';
+          }
+
+          if (!values.tileUrl.trim()) {
+            errors.tileUrl = 'Tile URL is required';
+          } else if (!validateTileUrl(values.tileUrl)) {
+            errors.tileUrl = 'Must include {z}, {x}, and {y} placeholders';
+          }
+
+          return errors;
+        }}
         onSubmit={function onSubmit({ name, tileUrl }) {
-          setFormError(null);
-
-          // Validate name
-          if (!name.trim()) {
-            setFormError('Please provide a name for the layer.');
-            return;
-          }
-
-          // Validate tile URL
-          if (!tileUrl.trim()) {
-            setFormError('Please provide a tile URL.');
-            return;
-          }
-
-          if (!validateTileUrl(tileUrl)) {
-            setFormError(
-              'Tile URL must include {z}, {x}, and {y} placeholders.'
-            );
-            return;
-          }
-
           if (isEditing) {
             // Update existing layer
             const updatedLayers = customRasterLayers.map((layer) =>
@@ -84,15 +76,20 @@ export function RasterLayerDialog({
             setCustomRasterLayers(updatedLayers);
             toast.success('Raster layer updated');
           } else {
-            // Add new layer
+            // Add new layer at the top of the stack
             const newLayer = {
               id: uuidv4(),
               name,
               tileUrl,
-              order: customRasterLayers.length,
+              order: 0,
               visible: true
             };
-            setCustomRasterLayers([...customRasterLayers, newLayer]);
+            // Increment order of all existing layers
+            const updatedExistingLayers = customRasterLayers.map((layer) => ({
+              ...layer,
+              order: layer.order + 1
+            }));
+            setCustomRasterLayers([newLayer, ...updatedExistingLayers]);
             toast.success('Raster layer added');
           }
 
@@ -110,11 +107,10 @@ export function RasterLayerDialog({
             />
             <LabeledTextField
               type="text"
-              label="Tile URL"
+              label="Tile URL template"
               name="tileUrl"
               placeholder="https://example.com/tiles/{z}/{x}/{y}.png"
             />
-            {formError && <InlineError>{formError}</InlineError>}
             <TextWell>
               Provide a tile URL template with {'{z}'}, {'{x}'}, and {'{y}'}{' '}
               placeholders for zoom level and tile coordinates.

--- a/next/app/components/dialogs/raster_layer.tsx
+++ b/next/app/components/dialogs/raster_layer.tsx
@@ -1,0 +1,136 @@
+import { LayersIcon } from '@radix-ui/react-icons';
+import { DialogHeader } from 'app/components/dialog';
+import SimpleDialogActions from 'app/components/dialogs/simple_dialog_actions';
+import { TextWell } from 'app/components/elements';
+import { InlineError } from 'app/components/inline_error';
+import { LabeledTextField } from 'app/core/components/LabeledTextField';
+import { Form, Formik } from 'formik';
+import { useAtom } from 'jotai';
+import { useState } from 'react';
+import { customRasterLayersAtom } from 'state/jotai';
+import type { DialogStateRasterLayer } from 'state/dialog_state';
+import { toast } from 'react-hot-toast';
+import { v4 as uuidv4 } from 'uuid';
+
+interface RasterLayerFormValues {
+  name: string;
+  tileUrl: string;
+}
+
+function validateTileUrl(url: string): boolean {
+  // Check if the URL contains {z}, {x}, and {y} placeholders
+  return url.includes('{z}') && url.includes('{x}') && url.includes('{y}');
+}
+
+export function RasterLayerDialog({
+  modal,
+  onClose
+}: {
+  modal: DialogStateRasterLayer;
+  onClose: () => void;
+}) {
+  const [customRasterLayers, setCustomRasterLayers] = useAtom(
+    customRasterLayersAtom
+  );
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const isEditing = !!modal.editingLayer;
+  const initialValues: RasterLayerFormValues = isEditing
+    ? {
+        name: modal.editingLayer.name,
+        tileUrl: modal.editingLayer.tileUrl
+      }
+    : {
+        name: '',
+        tileUrl: ''
+      };
+
+  return (
+    <>
+      <DialogHeader
+        title={isEditing ? 'Edit Raster Layer' : 'Add Raster Layer'}
+        titleIcon={LayersIcon}
+      />
+      <Formik<RasterLayerFormValues>
+        onSubmit={function onSubmit({ name, tileUrl }) {
+          setFormError(null);
+
+          // Validate name
+          if (!name.trim()) {
+            setFormError('Please provide a name for the layer.');
+            return;
+          }
+
+          // Validate tile URL
+          if (!tileUrl.trim()) {
+            setFormError('Please provide a tile URL.');
+            return;
+          }
+
+          if (!validateTileUrl(tileUrl)) {
+            setFormError(
+              'Tile URL must include {z}, {x}, and {y} placeholders.'
+            );
+            return;
+          }
+
+          if (isEditing) {
+            // Update existing layer
+            const updatedLayers = customRasterLayers.map((layer) =>
+              layer.id === modal.editingLayer!.id
+                ? { ...layer, name, tileUrl, visible: layer.visible ?? true }
+                : layer
+            );
+            setCustomRasterLayers(updatedLayers);
+            toast.success('Raster layer updated');
+          } else {
+            // Add new layer
+            const newLayer = {
+              id: uuidv4(),
+              name,
+              tileUrl,
+              order: customRasterLayers.length,
+              visible: true
+            };
+            setCustomRasterLayers([...customRasterLayers, newLayer]);
+            toast.success('Raster layer added');
+          }
+
+          onClose();
+        }}
+        initialValues={initialValues}
+      >
+        <Form>
+          <div className="space-y-4">
+            <LabeledTextField
+              type="text"
+              label="Layer Name"
+              name="name"
+              placeholder="My Custom Layer"
+            />
+            <LabeledTextField
+              type="text"
+              label="Tile URL"
+              name="tileUrl"
+              placeholder="https://example.com/tiles/{z}/{x}/{y}.png"
+            />
+            {formError && <InlineError>{formError}</InlineError>}
+            <TextWell>
+              Provide a tile URL template with {'{z}'}, {'{x}'}, and {'{y}'}{' '}
+              placeholders for zoom level and tile coordinates.
+            </TextWell>
+            <TextWell>
+              <strong>Note:</strong> Your raster layer configuration will be
+              saved in your browser's local storage and will not be available if
+              you switch browsers or clear your browsing data.
+            </TextWell>
+          </div>
+          <SimpleDialogActions
+            onClose={onClose}
+            action={isEditing ? 'Update' : 'Add'}
+          />
+        </Form>
+      </Formik>
+    </>
+  );
+}

--- a/next/app/components/dialogs/simple_dialog_actions.tsx
+++ b/next/app/components/dialogs/simple_dialog_actions.tsx
@@ -19,7 +19,7 @@ export default function SimpleDialogActions({
   };
   variant?: 'md' | 'xs';
 }) {
-  const { isSubmitting } = useFormikContext();
+  const { isSubmitting, isValid } = useFormikContext();
   return (
     <div
       className={clsx(
@@ -33,7 +33,7 @@ export default function SimpleDialogActions({
       {action ? (
         <Button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || !isValid}
           variant="primary"
           size={fullWidthSubmit ? 'full-width' : 'sm'}
         >

--- a/next/app/components/map_component.tsx
+++ b/next/app/components/map_component.tsx
@@ -33,7 +33,8 @@ import {
   Mode,
   modeAtom,
   selectedFeaturesAtom,
-  styleOptionsAtom
+  styleOptionsAtom,
+  customRasterLayersAtom
 } from 'state/jotai';
 import type { DragTarget, HandlerContext, IWrappedFeature } from 'types';
 import { SYMBOLIZATION_NONE } from 'types';
@@ -74,6 +75,8 @@ export const MapComponent = memo(function MapComponent({
   const styleConfig = useAtomValue(styleConfigAtom);
 
   const styleOptions = useAtomValue(styleOptionsAtom);
+
+  const customRasterLayers = useAtomValue(customRasterLayersAtom);
 
   const zoomTo = useZoomTo();
 
@@ -200,11 +203,21 @@ export const MapComponent = memo(function MapComponent({
           styleConfig,
           symbolization: symbolization || SYMBOLIZATION_NONE,
           previewProperty: label,
-          styleOptions
+          styleOptions,
+          customRasterLayers
         })
         .catch((e) => captureException(e));
     },
-    [map, symbolization, data, styleConfig, ephemeralState, label, styleOptions]
+    [
+      map,
+      symbolization,
+      data,
+      styleConfig,
+      ephemeralState,
+      label,
+      styleOptions,
+      customRasterLayers
+    ]
   );
 
   const throttledMovePointer = useMemo(() => {

--- a/next/app/components/styles/popover.tsx
+++ b/next/app/components/styles/popover.tsx
@@ -34,6 +34,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { memo } from 'react';
+import { toast } from 'react-hot-toast';
 
 const SortableRasterLayer = memo(function SortableRasterLayer({
   layer,
@@ -137,9 +138,8 @@ export function StylesPopover() {
   };
 
   const handleDeleteRasterLayer = (id: string) => {
-    if (confirm('Are you sure you want to remove this raster layer?')) {
-      setCustomRasterLayers(customRasterLayers.filter((l) => l.id !== id));
-    }
+    setCustomRasterLayers(customRasterLayers.filter((l) => l.id !== id));
+    toast.success('Raster layer removed');
   };
 
   const handleToggleVisibility = (id: string) => {

--- a/next/app/components/styles/popover.tsx
+++ b/next/app/components/styles/popover.tsx
@@ -1,12 +1,172 @@
 import * as E from 'app/components/elements';
 import { styledCheckbox } from 'app/components/elements';
 import LAYERS from 'app/lib/default_styles';
-import { activeStyleIdAtom, styleOptionsAtom } from 'state/jotai';
-import { useAtom } from 'jotai';
+import {
+  activeStyleIdAtom,
+  styleOptionsAtom,
+  customRasterLayersAtom,
+  type CustomRasterLayer
+} from 'state/jotai';
+import { useAtom, useSetAtom } from 'jotai';
+import { dialogAtom } from 'state/jotai';
+import { DialogHelpers } from 'state/dialog_helpers';
+import {
+  PlusIcon,
+  Pencil1Icon,
+  TrashIcon,
+  DragHandleDots2Icon,
+  EyeOpenIcon,
+  EyeNoneIcon
+} from '@radix-ui/react-icons';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { memo } from 'react';
+
+const SortableRasterLayer = memo(function SortableRasterLayer({
+  layer,
+  onEdit,
+  onDelete,
+  onToggleVisibility
+}: {
+  layer: CustomRasterLayer;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleVisibility: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: layer.id });
+
+  const style: React.HTMLAttributes<HTMLDivElement>['style'] = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700"
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        className="cursor-grab active:cursor-grabbing p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+        aria-label="Drag to reorder"
+      >
+        <DragHandleDots2Icon className="w-4 h-4 text-gray-500" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate">{layer.name}</div>
+        <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+          {layer.tileUrl}
+        </div>
+      </div>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={onToggleVisibility}
+          className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+          type="button"
+          aria-label={layer.visible !== false ? 'Hide layer' : 'Show layer'}
+        >
+          {layer.visible !== false ? (
+            <EyeOpenIcon className="w-4 h-4" />
+          ) : (
+            <EyeNoneIcon className="w-4 h-4" />
+          )}
+        </button>
+        <button
+          onClick={onEdit}
+          className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+          type="button"
+          aria-label="Edit layer"
+        >
+          <Pencil1Icon className="w-4 h-4" />
+        </button>
+        <button
+          onClick={onDelete}
+          className="p-1 hover:bg-red-200 dark:hover:bg-red-900 rounded text-red-600 dark:text-red-400"
+          type="button"
+          aria-label="Delete layer"
+        >
+          <TrashIcon className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+});
 
 export function StylesPopover() {
   const [activeStyleId, setActiveStyleId] = useAtom(activeStyleIdAtom);
   const [styleOptions, setStyleOptions] = useAtom(styleOptionsAtom);
+  const [customRasterLayers, setCustomRasterLayers] = useAtom(
+    customRasterLayersAtom
+  );
+  const setDialogState = useSetAtom(dialogAtom);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8
+      }
+    })
+  );
+
+  const handleAddRasterLayer = () => {
+    setDialogState(DialogHelpers.addRasterLayer());
+  };
+
+  const handleEditRasterLayer = (layer: {
+    id: string;
+    name: string;
+    tileUrl: string;
+  }) => {
+    setDialogState(DialogHelpers.editRasterLayer(layer));
+  };
+
+  const handleDeleteRasterLayer = (id: string) => {
+    if (confirm('Are you sure you want to remove this raster layer?')) {
+      setCustomRasterLayers(customRasterLayers.filter((l) => l.id !== id));
+    }
+  };
+
+  const handleToggleVisibility = (id: string) => {
+    setCustomRasterLayers(
+      customRasterLayers.map((layer) =>
+        layer.id === id
+          ? { ...layer, visible: layer.visible !== false ? false : true }
+          : layer
+      )
+    );
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = customRasterLayers.findIndex((l) => l.id === active.id);
+      const newIndex = customRasterLayers.findIndex((l) => l.id === over.id);
+
+      const newLayers = arrayMove(customRasterLayers, oldIndex, newIndex);
+      // Update order values
+      newLayers.forEach((layer, i) => {
+        layer.order = i;
+      });
+      setCustomRasterLayers(newLayers);
+    }
+  };
 
   return (
     <div>
@@ -81,6 +241,47 @@ export function StylesPopover() {
               Show map labels
             </E.StyledLabelSpan>
           </span>
+        )}
+      </div>
+
+      {/* Raster Layers section */}
+      <div className="pt-3 border-t border-gray-100 dark:border-gray-700">
+        <div className="flex justify-between pb-2 px-2">
+          <div className="font-bold">Raster Layers</div>
+          <button
+            onClick={handleAddRasterLayer}
+            className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+            type="button"
+            aria-label="Add raster layer"
+          >
+            <PlusIcon />
+            Add Layer
+          </button>
+        </div>
+
+        {customRasterLayers.length > 0 && (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={customRasterLayers.map((l) => l.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2 px-2 max-h-48 overflow-y-auto">
+                {customRasterLayers.map((layer) => (
+                  <SortableRasterLayer
+                    key={layer.id}
+                    layer={layer}
+                    onEdit={() => handleEditRasterLayer(layer)}
+                    onDelete={() => handleDeleteRasterLayer(layer.id)}
+                    onToggleVisibility={() => handleToggleVisibility(layer.id)}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
         )}
       </div>
     </div>

--- a/next/app/lib/default_styles.ts
+++ b/next/app/lib/default_styles.ts
@@ -88,6 +88,9 @@ const STYLES: Record<string, StyleConfigTemplate> = {
     name: 'OSM',
     json: {
       version: 8,
+      // sprite and glyphs are unused, but required to prevent an error when switching to this style
+      sprite: 'mapbox://sprites/mapbox/streets-v8',
+      glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
       sources: {
         'osm-tiles': {
           type: 'raster',

--- a/next/app/lib/load_and_augment_style.ts
+++ b/next/app/lib/load_and_augment_style.ts
@@ -5,7 +5,7 @@ import {
 import { addMapboxStyle } from 'app/lib/style_config_adapters';
 // TODO: this is a UI concern that should be separate.
 import type { Style } from 'mapbox-gl';
-import type { PreviewProperty } from 'state/jotai';
+import type { PreviewProperty, CustomRasterLayer } from 'state/jotai';
 import type { ISymbolization, IStyleConfig, StyleOptions } from 'types';
 
 function getEmptyStyle() {
@@ -73,15 +73,22 @@ export default async function loadAndAugmentStyle({
   styleConfig,
   symbolization,
   previewProperty,
-  styleOptions
+  styleOptions,
+  customRasterLayers = []
 }: {
   styleConfig: IStyleConfig;
   symbolization: ISymbolization;
   previewProperty: PreviewProperty;
   styleOptions: StyleOptions;
+  customRasterLayers?: CustomRasterLayer[];
 }): Promise<Style> {
   let style = getEmptyStyle();
-  style = await addMapboxStyle(style, styleConfig, styleOptions);
+  style = await addMapboxStyle(
+    style,
+    styleConfig,
+    styleOptions,
+    customRasterLayers
+  );
   addEditingLayers({ style, symbolization, previewProperty });
   return style;
 }

--- a/next/app/lib/pmap/index.ts
+++ b/next/app/lib/pmap/index.ts
@@ -26,7 +26,8 @@ import type {
   Data,
   EphemeralEditingState,
   PreviewProperty,
-  Sel
+  Sel,
+  CustomRasterLayer
 } from 'state/jotai';
 import type {
   Feature,
@@ -118,6 +119,7 @@ export default class PMap {
   lastLayer: IStyleConfig | null;
   lastPreviewProperty: PreviewProperty;
   lastStyleOptions: StyleOptions | null;
+  lastCustomRasterLayers: CustomRasterLayer[] | null;
   overlay: MapboxOverlay;
 
   constructor({
@@ -199,6 +201,7 @@ export default class PMap {
     this.lastLayer = null;
     this.lastPreviewProperty = null;
     this.lastStyleOptions = null;
+    this.lastCustomRasterLayers = null;
     this.handlers = handlers;
     this.map = map;
     void this.setStyle({
@@ -401,25 +404,34 @@ export default class PMap {
     styleConfig,
     symbolization,
     previewProperty,
-    styleOptions
+    styleOptions,
+    customRasterLayers = []
   }: {
     styleConfig: IStyleConfig;
     symbolization: ISymbolization;
     previewProperty: PreviewProperty;
     styleOptions: StyleOptions;
+    customRasterLayers?: CustomRasterLayer[];
   }) {
+    // Check if custom raster layers changed
+    const customRasterLayersChanged =
+      JSON.stringify(this.lastCustomRasterLayers) !==
+      JSON.stringify(customRasterLayers);
+
     // If only styleOptions changed, and the style has imports, update config properties instead of reloading style
     const onlyStyleOptionsChanged =
       styleConfig === this.lastLayer &&
       symbolization === this.lastSymbolization &&
       previewProperty === this.lastPreviewProperty &&
-      styleOptions !== this.lastStyleOptions;
+      styleOptions !== this.lastStyleOptions &&
+      !customRasterLayersChanged;
 
     if (
       styleConfig === this.lastLayer &&
       symbolization === this.lastSymbolization &&
       previewProperty === this.lastPreviewProperty &&
-      styleOptions === this.lastStyleOptions
+      styleOptions === this.lastStyleOptions &&
+      !customRasterLayersChanged
     ) {
       return;
     }
@@ -429,12 +441,14 @@ export default class PMap {
     this.lastSymbolization = symbolization;
     this.lastPreviewProperty = previewProperty;
     this.lastStyleOptions = styleOptions;
+    this.lastCustomRasterLayers = customRasterLayers;
 
     const style = await loadAndAugmentStyle({
       styleConfig,
       symbolization,
       previewProperty,
-      styleOptions
+      styleOptions,
+      customRasterLayers
     });
 
     // If only styleOptions changed and style has imports, update config properties instead of reloading style

--- a/next/app/lib/style_config_adapters.ts
+++ b/next/app/lib/style_config_adapters.ts
@@ -124,8 +124,6 @@ function updateMapboxStyle(
     })
     .filter(Boolean) as mapboxgl.AnyLayer[];
 
-  // Add custom raster layers to the layers array
-  // Insert them at the beginning so they appear below the basemap
   // Reverse the order so layers at the top of the UI list render on top on the map
   const customRasterMapboxLayers: mapboxgl.AnyLayer[] =
     visibleCustomRasterLayers
@@ -162,10 +160,18 @@ function updateMapboxStyle(
     });
   }
 
+  // For import-based styles (Standard variants), layers in the parent style render
+  // above the imported basemap, so custom rasters go at the start of layers.
+  // For traditional styles (Outdoors, OSM), basemap layers are in the layers array
+  // directly, so custom rasters must go at the end to appear on top of the basemap.
+  const layers = style.imports
+    ? [...customRasterMapboxLayers, ...updatedLayers]
+    : [...updatedLayers, ...customRasterMapboxLayers];
+
   const result: any = {
     ...style,
     sources: updatedSources,
-    layers: [...customRasterMapboxLayers, ...updatedLayers]
+    layers
   };
   if (typeof updatedImports !== 'undefined') {
     result.imports = updatedImports;

--- a/next/app/lib/style_config_adapters.ts
+++ b/next/app/lib/style_config_adapters.ts
@@ -3,6 +3,7 @@ import once from 'lodash/once';
 import mapboxgl from 'mapbox-gl';
 import { toast } from 'react-hot-toast';
 import type { IStyleConfig, StyleOptions } from 'types';
+import type { CustomRasterLayer } from 'state/jotai';
 
 const warnOffline = once(() => {
   toast.error('Offline: falling back to blank background');
@@ -11,7 +12,8 @@ const warnOffline = once(() => {
 export async function addMapboxStyle(
   _base: mapboxgl.Style,
   layer: IStyleConfig,
-  styleOptions: StyleOptions
+  styleOptions: StyleOptions,
+  customRasterLayers: CustomRasterLayer[] = []
 ): Promise<mapboxgl.Style> {
   let style: mapboxgl.Style;
 
@@ -42,7 +44,8 @@ export async function addMapboxStyle(
   }
 
   const updatedStyle = updateMapboxStyle(style, {
-    labelVisibility: styleOptions.labelVisibility
+    labelVisibility: styleOptions.labelVisibility,
+    customRasterLayers
   });
   return updatedStyle;
 }
@@ -52,13 +55,32 @@ function updateMapboxStyle(
   options: {
     labelVisibility?: boolean;
     rasterOpacity?: number;
+    customRasterLayers?: CustomRasterLayer[];
   }
 ): mapboxgl.Style {
-  const { labelVisibility = true, rasterOpacity } = options;
+  const {
+    labelVisibility = true,
+    rasterOpacity,
+    customRasterLayers = []
+  } = options;
 
   if (!style.layers) {
     return style;
   }
+
+  // Add custom raster sources
+  const updatedSources = { ...style.sources };
+  // Only include visible layers
+  const visibleCustomRasterLayers = customRasterLayers.filter(
+    (layer) => layer.visible !== false
+  );
+  visibleCustomRasterLayers.forEach((layer) => {
+    updatedSources[`custom-raster-${layer.id}`] = {
+      type: 'raster',
+      tiles: [layer.tileUrl],
+      tileSize: 256
+    } as mapboxgl.RasterSource;
+  });
 
   const isSatelliteStyle =
     style.name === 'Mapbox Satellite Streets' ||
@@ -102,6 +124,24 @@ function updateMapboxStyle(
     })
     .filter(Boolean) as mapboxgl.AnyLayer[];
 
+  // Add custom raster layers to the layers array
+  // Insert them at the beginning so they appear below the basemap
+  // Reverse the order so layers at the top of the UI list render on top on the map
+  const customRasterMapboxLayers: mapboxgl.AnyLayer[] =
+    visibleCustomRasterLayers
+      .slice()
+      .reverse()
+      .map((layer) => ({
+        id: `custom-raster-layer-${layer.id}`,
+        type: 'raster',
+        source: `custom-raster-${layer.id}`,
+        minzoom: 0,
+        maxzoom: 22,
+        paint: {
+          'raster-emissive-strength': 1
+        }
+      }));
+
   let updatedImports = style.imports;
   // update imports for styles that use Mapbox standard or standard satellite style
   if (style.imports) {
@@ -124,7 +164,8 @@ function updateMapboxStyle(
 
   const result: any = {
     ...style,
-    layers: updatedLayers
+    sources: updatedSources,
+    layers: [...customRasterMapboxLayers, ...updatedLayers]
   };
   if (typeof updatedImports !== 'undefined') {
     result.imports = updatedImports;

--- a/next/state/dialog_helpers.ts
+++ b/next/state/dialog_helpers.ts
@@ -8,7 +8,8 @@ import type {
   DialogStateImportNotes,
   DialogStateCastProperty,
   DialogStateBuffer,
-  DialogStateSimplify
+  DialogStateSimplify,
+  DialogStateRasterLayer
 } from './dialog_state';
 
 /**
@@ -35,6 +36,14 @@ export const DIALOG_CONFIGS = {
   circle_types: {
     title: 'Circle Type',
     description: 'Choose circle creation method'
+  },
+  raster_layer: {
+    title: 'Add Raster Layer',
+    description: 'Configure custom raster layer'
+  },
+  edit_raster_layer: {
+    title: 'Edit Raster Layer',
+    description: 'Edit custom raster layer'
   }
 } as const;
 
@@ -112,5 +121,20 @@ export const DialogHelpers = {
     title: 'Create Circle',
     description: 'Configure circle parameters',
     position
+  }),
+
+  addRasterLayer: (): DialogStateRasterLayer => ({
+    type: 'raster_layer',
+    ...DIALOG_CONFIGS.raster_layer
+  }),
+
+  editRasterLayer: (layer: {
+    id: string;
+    name: string;
+    tileUrl: string;
+  }): DialogStateRasterLayer => ({
+    type: 'raster_layer',
+    ...DIALOG_CONFIGS.edit_raster_layer,
+    editingLayer: layer
   })
 };

--- a/next/state/dialog_state.ts
+++ b/next/state/dialog_state.ts
@@ -50,6 +50,17 @@ export type DialogStateSimplify = {
   features: IWrappedFeature<IFeature<SimplifySupportedGeometry>>[];
 };
 
+export type DialogStateRasterLayer = {
+  type: 'raster_layer';
+  title: string;
+  description: string;
+  editingLayer?: {
+    id: string;
+    name: string;
+    tileUrl: string;
+  };
+};
+
 type DialogState =
   | DialogStateImport
   | DialogStateImportNotes
@@ -57,6 +68,7 @@ type DialogState =
   | DialogStateSimplify
   | DialogStateBuffer
   | DialogStateCircle
+  | DialogStateRasterLayer
   | {
       type: 'circle_types';
       title: string;

--- a/next/state/jotai.ts
+++ b/next/state/jotai.ts
@@ -68,6 +68,21 @@ export const styleOptionsAtom = atomWithStorage<StyleOptions>('styleOptions', {
   labelVisibility: true
 });
 
+// Custom raster layer configuration
+export interface CustomRasterLayer {
+  id: string;
+  name: string;
+  tileUrl: string;
+  order: number;
+  visible?: boolean;
+}
+
+// tracks custom raster layers added by the user
+export const customRasterLayersAtom = atomWithStorage<CustomRasterLayer[]>(
+  'customRasterLayers',
+  []
+);
+
 export const styleConfigAtom = atom((get) => {
   const activeId = get(activeStyleIdAtom);
   const baseLayer = LAYERS[activeId] || LAYERS.STANDARD_LIGHT;


### PR DESCRIPTION
## Add Custom Raster Layers Feature

Adds a custom raster layer management system to the layer menu with full CRUD operations, drag-and-drop reordering, and visibility controls.

### Features

**Layer Management**
- New "Raster Layers" section in layer menu with add/edit/delete operations
- Drag-and-drop reordering using `@dnd-kit` (top layer renders on top of map)
- Visibility toggle with eye icons (show/hide without deleting)
- Persists to localStorage (browser-specific)

**User Experience**
- Form validation: requires layer name and tile URL with `{z}`, `{x}`, `{y}` placeholders
- Submit button disabled until form is valid
- Toast notifications for add/update/delete actions
- New layers added to top of stack for immediate visual feedback

**Map Integration**
- Custom raster sources injected into Mapbox style
- Rendered with `raster-emissive-strength: 1` for visibility
- Automatic map updates when layers change
- Proper change detection to avoid unnecessary reloads

### Technical Changes

**New Components**
- `RasterLayerDialog`: Modal form with Formik validation
- `SortableRasterLayer`: DnD-enabled layer item

**State Management**
- `CustomRasterLayer` interface with `id`, `name`, `tileUrl`, `order`, `visible`
- `customRasterLayersAtom` using Jotai's `atomWithStorage`

**Modified Files**
- Style adapters to inject custom raster layers
- Map component to connect layers to Mapbox instance
- Dialog system routing and helpers

### Use Cases
- Overlay historical maps or custom basemaps
- Display specialized data layers (weather, traffic, etc.)