### PR TITLE
Adding support for pitch/bearing

### DIFF
--- a/next/app/lib/pmap/index.ts
+++ b/next/app/lib/pmap/index.ts
@@ -43,7 +43,6 @@ const MAP_OPTIONS: Omit<mapboxgl.MapboxOptions, 'container'> = {
   style: { version: 8, layers: [], sources: {} },
   maxZoom: 26,
   boxZoom: false,
-  dragRotate: false,
   attributionControl: false,
   fadeDuration: 0
 };
@@ -344,6 +343,7 @@ export default class PMap {
           pickable: true,
           stroked: true,
           filled: true,
+          billboard: true,
 
           data: groups.synthetic,
 


### PR DESCRIPTION
This PR enables the map to be rotated and pitched.  This is a small boolean in the map declaration & and the addition of the the `billboard` property in the `ScatterPlot` layer.  The `billboard` property allows Deck GL to orient the Scatterplot layer, perpendicular to the camera, ensuring that the vertices are always visible even at high pitch.  


## Testing

Pull down the local branch, create a few features, pitch & rotate the map to test.