### PR TITLE
Support legacy hash-based #data= URL params

### DIFF
--- a/next/app/components/url_api.tsx
+++ b/next/app/components/url_api.tsx
@@ -52,7 +52,6 @@ export function UrlAPI() {
     if (!map) return; // Wait for map to be available
 
     // Handle legacy hash-based data params (e.g. #data=data:application/json,... or #data=data:text/x-url,...)
-    // Normalize to canonical ?data= query param and update the URL
     let legacyData: string | null = null;
     const hashString = window.location.hash;
     if (!data && !id && !gist && hashString.startsWith('#data=')) {
@@ -65,11 +64,6 @@ export function UrlAPI() {
         // data:application/json,... or other — pass through as-is
         legacyData = decodedHashValue;
       }
-      // Rewrite the URL to canonical ?data= form without a page reload
-      const newUrl = new URL(window.location.href);
-      newUrl.hash = '';
-      newUrl.searchParams.set('data', legacyData);
-      window.history.replaceState(null, '', newUrl.toString());
     }
 
     // Helper to fetch and import from a URL
@@ -181,9 +175,10 @@ export function UrlAPI() {
       }
     };
 
-    const stripQueryParams = (...keys: string[]) => {
+    const cleanUrl = (removeHash: boolean, ...queryKeys: string[]) => {
       const newUrl = new URL(window.location.href);
-      for (const key of keys) newUrl.searchParams.delete(key);
+      for (const key of queryKeys) newUrl.searchParams.delete(key);
+      if (removeHash) newUrl.hash = '';
       window.history.replaceState(null, '', newUrl.toString());
     };
 
@@ -193,11 +188,11 @@ export function UrlAPI() {
         if (effectiveData) {
           done.current = true;
           await handleDataParam(effectiveData);
-          stripQueryParams('data');
+          cleanUrl(!!legacyData, 'data');
         } else if (id) {
           done.current = true;
           await handleIdParam(id);
-          stripQueryParams('id');
+          cleanUrl(false, 'id');
         }
       } catch (e) {
         toast.error(

--- a/next/app/components/url_api.tsx
+++ b/next/app/components/url_api.tsx
@@ -181,15 +181,23 @@ export function UrlAPI() {
       }
     };
 
+    const stripQueryParams = (...keys: string[]) => {
+      const newUrl = new URL(window.location.href);
+      for (const key of keys) newUrl.searchParams.delete(key);
+      window.history.replaceState(null, '', newUrl.toString());
+    };
+
     (async () => {
       try {
         const effectiveData = legacyData ?? data;
         if (effectiveData) {
           done.current = true;
           await handleDataParam(effectiveData);
+          stripQueryParams('data');
         } else if (id) {
           done.current = true;
           await handleIdParam(id);
+          stripQueryParams('id');
         }
       } catch (e) {
         toast.error(

--- a/next/app/components/url_api.tsx
+++ b/next/app/components/url_api.tsx
@@ -51,6 +51,27 @@ export function UrlAPI() {
     if (done.current) return;
     if (!map) return; // Wait for map to be available
 
+    // Handle legacy hash-based data params (e.g. #data=data:application/json,... or #data=data:text/x-url,...)
+    // Normalize to canonical ?data= query param and update the URL
+    let legacyData: string | null = null;
+    const hashString = window.location.hash;
+    if (!data && !id && !gist && hashString.startsWith('#data=')) {
+      const rawHashValue = hashString.slice('#data='.length);
+      const decodedHashValue = decodeURIComponent(rawHashValue);
+      if (decodedHashValue.startsWith('data:text/x-url,')) {
+        // Extract the bare URL from the x-url wrapper
+        legacyData = decodedHashValue.slice('data:text/x-url,'.length);
+      } else {
+        // data:application/json,... or other — pass through as-is
+        legacyData = decodedHashValue;
+      }
+      // Rewrite the URL to canonical ?data= form without a page reload
+      const newUrl = new URL(window.location.href);
+      newUrl.hash = '';
+      newUrl.searchParams.set('data', legacyData);
+      window.history.replaceState(null, '', newUrl.toString());
+    }
+
     // Helper to fetch and import from a URL
     const fetchAndImport = async (url: string, name?: string) => {
       const res = await fetch(url);
@@ -162,9 +183,10 @@ export function UrlAPI() {
 
     (async () => {
       try {
-        if (data) {
+        const effectiveData = legacyData ?? data;
+        if (effectiveData) {
           done.current = true;
-          await handleDataParam(data);
+          await handleDataParam(effectiveData);
         } else if (id) {
           done.current = true;
           await handleIdParam(id);


### PR DESCRIPTION
## Summary                                                                
                                                            
  Adds support for the legacy hash-based URL formats used by older versions 
  of geojson.io, and cleans up the URL after data loads.
                                                                            
  **Legacy hash formats supported:**                        
  - `#data=data:application/json,<encoded-geojson>` — inline GeoJSON
  - `#data=data:text/x-url,<encoded-url>` — remote file via URL             
                                                                            
  In both cases the data is loaded and the hash is cleared from the URL on  
  success. The existing `?data=` and `?id=` query params also have their    
  params stripped after a successful load.                                  
                                                            
  **Before:** Legacy URLs would fail silently or not load at all. Query     
  param URLs would persist in the address bar after loading.
                                                                            
  **After:** All URL formats load correctly, and the address bar is clean   
  after data loads. Failed loads leave the URL intact so the user can see
  what went wrong.                                                          
                                                            
  ## Test plan

  - [x] `#data=data:text/x-url,https%3A%2F%2Fraw.githubusercontent.com%2Fcod
  eforgermany%2Fclick_that_hood%2Fmain%2Fpublic%2Fdata%2Fcalifornia-counties
  .geojson` — loads remote GeoJSON, hash disappears                         
  - [x] `#data=data:application/json,%7B%22type%22%3A%22LineString%22%2C%22c
  oordinates%22%3A%5B%5B0%2C0%5D%2C%5B10%2C10%5D%5D%7D` — loads inline      
  GeoJSON, hash disappears
  - [ ] `?data=<url>` — loads data, `?data=` param is removed after load    
  - [x] `?id=gist:...` — loads gist, `?id=` param is removed after load     
  - [x] Failed loads leave the URL unchanged   