### PR TITLE
Localize keyboard shortcuts for Mac vs Windows/Linux

### DIFF
--- a/next/app/components/about_modal.tsx
+++ b/next/app/components/about_modal.tsx
@@ -6,6 +6,7 @@ import { Keycap } from './elements';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import { DialogHeader } from 'app/components/dialog';
+import { getIsMac, localizeKeybinding } from 'app/lib/utils';
 
 // Utility to extract headings from markdown
 function extractHeadings(markdown: string) {
@@ -27,6 +28,12 @@ function extractHeadings(markdown: string) {
   return headings;
 }
 
+const isMac = getIsMac();
+
+function localizeMarkdown(md: string): string {
+  return localizeKeybinding(md, isMac);
+}
+
 export default function AboutModal({ open }: { open: boolean }) {
   const [markdown, setMarkdown] = useState<string>('');
   const [headings, setHeadings] = useState<
@@ -41,7 +48,7 @@ export default function AboutModal({ open }: { open: boolean }) {
       fetch('/next/about.md')
         .then((res) => res.text())
         .then((md) => {
-          setMarkdown(md);
+          setMarkdown(localizeMarkdown(md));
           setHeadings(extractHeadings(md));
         })
         .catch(() => setMarkdown('Failed to load info.'));

--- a/next/app/components/search/search_box_button.tsx
+++ b/next/app/components/search/search_box_button.tsx
@@ -29,7 +29,9 @@ const SearchBoxButton = () => {
               <span className="ml-2 text-gray-400">Search</span>
             </div>
 
-            <span className="text-gray-400 txt-bold">⌘K</span>
+            <span className="text-gray-400 txt-bold">
+              {localizeKeybinding(SEARCH_KEYBINDING, isMac)}
+            </span>
           </E.Button>
         </T.Trigger>
         <E.TContent>

--- a/next/app/lib/utils.ts
+++ b/next/app/lib/utils.ts
@@ -90,8 +90,8 @@ export const MAC_CMD_SYMBOL = '⌘';
 
 export function localizeKeybinding(keys: string, isMac: boolean): string {
   return keys
-    .replace('Command', isMac ? MAC_CMD_SYMBOL : 'Ctrl')
-    .replace('Option', isMac ? 'Option' : 'Alt');
+    .replace(/Command/g, isMac ? MAC_CMD_SYMBOL : 'Ctrl')
+    .replace(/Option/g, isMac ? 'Option' : 'Alt');
 }
 
 type ClipboardInput = Promisable<string>;

--- a/next/public/about.md
+++ b/next/public/about.md
@@ -37,7 +37,7 @@ Select a feature to edit its geometry.
 - <kbd>Delete</kbd> to delete a selected vertex.
 - <kbd>Option</kbd> + drag a vertex to snap to nearby features.
 - Hold <kbd>Space</kbd> and drag to move a feature.
-- <kbd>CMD</kbd> + <kbd>Option</kbd> + drag to rotate a feature.
+- <kbd>Command</kbd> + <kbd>Option</kbd> + drag to rotate a feature.
 
 ### Editing Properties
 
@@ -97,12 +97,12 @@ When export GeoJSON, geojson.io always exports a FeatureCollection.
     <tr><td><kbd>Esc</kbd></td><td>Exit drawing / clear selection</td></tr>
     <tr><td><kbd>]</kbd></td><td>Next panel</td></tr>
     <tr><td><kbd>[</kbd></td><td>Previous panel</td></tr>
-    <tr><td><kbd>⌘+k</kbd></td><td>Search</td></tr>
-    <tr><td><kbd>⌘+o</kbd></td><td>Open</td></tr>
-    <tr><td><kbd>⌘+s</kbd></td><td>Save</td></tr>
-    <tr><td><kbd>⌘+a</kbd></td><td>Select all</td></tr>
-    <tr><td><kbd>⌘+z</kbd></td><td>Undo</td></tr>
-    <tr><td><kbd>⌘+y</kbd></td><td>Redo</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>k</kbd></td><td>Search</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>o</kbd></td><td>Open</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>s</kbd></td><td>Save</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>a</kbd></td><td>Select all</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>z</kbd></td><td>Undo</td></tr>
+    <tr><td><kbd>Command</kbd> + <kbd>y</kbd></td><td>Redo</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

- `search_box_button.tsx`: replace hardcoded `⌘K` label with `localizeKeybinding()` so it shows `Ctrl+K` on Windows/Linux
- `about.md`: standardize all modifier key references to use `Command` (replacing `⌘` and `CMD`), then process the markdown through `localizeKeybinding()` on load so it renders platform-appropriately
- `localizeKeybinding()`: fix `.replace()` to use a global regex so all occurrences in a string are replaced, not just the first

Screenshot of the about panel when viewed on a Windows machine (edge browser)
<img width="1306" height="992" alt="geojson" src="https://github.com/user-attachments/assets/01935fea-a824-4141-8b4d-c90c5c7e2485" />


## Test plan

- [ ] On Mac: search button shows `⌘K`, about modal shows `⌘` for all shortcuts
- [ ] On Windows/Linux: search button shows `Ctrl+K`, about modal shows `Ctrl` for all shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)