### PR TITLE
Add legacy-app cutover notice modal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,8 @@ gjIO.router.on();
 
 api(gjIO);
 
+require('./ui/cutover_notice')(gjIO);
+
 function geojsonIO() {
   const context = {};
   context.dispatch = d3.dispatch('change', 'route');

--- a/src/ui/cutover_notice.js
+++ b/src/ui/cutover_notice.js
@@ -4,6 +4,8 @@ const DISMISS_KEY = 'cutover_notice_dismissed_v1';
 const DISMISS_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 const NEXT_URL = '/next';
 const ISSUES_URL = 'https://github.com/mapbox/geojson.io/issues';
+const CHANGELOG_URL =
+  'https://github.com/mapbox/geojson.io/blob/main/next/CHANGELOG.md';
 
 module.exports = function (context) {
   const dismissedAt = context.storage.get(DISMISS_KEY);
@@ -33,6 +35,17 @@ module.exports = function (context) {
         NEXT_URL +
         '" target="_blank" class="underline">/next</a>) ' +
         'will replace this version.'
+    );
+
+  body
+    .append('p')
+    .attr('class', 'mb-4')
+    .html(
+      "We've been actively incorporating feedback from users — " +
+        '<a href="' +
+        CHANGELOG_URL +
+        '" target="_blank" rel="noopener" class="underline">' +
+        "see what's changed</a> in the new version."
     );
 
   body

--- a/src/ui/cutover_notice.js
+++ b/src/ui/cutover_notice.js
@@ -28,7 +28,6 @@ module.exports = function (context) {
 
   body
     .append('p')
-    .attr('class', 'mb-4')
     .html(
       'On <strong>June 1st</strong>, the new geojson.io (currently at ' +
         '<a href="' +
@@ -39,7 +38,6 @@ module.exports = function (context) {
 
   body
     .append('p')
-    .attr('class', 'mb-4')
     .html(
       "We've been actively incorporating feedback from users — " +
         '<a href="' +
@@ -50,7 +48,6 @@ module.exports = function (context) {
 
   body
     .append('p')
-    .attr('class', 'mb-4')
     .html(
       'Found a bug or have feedback on the new version? Please ' +
         '<a href="' +

--- a/src/ui/cutover_notice.js
+++ b/src/ui/cutover_notice.js
@@ -1,0 +1,78 @@
+const modal = require('./modal');
+
+const DISMISS_KEY = 'cutover_notice_dismissed_v1';
+const DISMISS_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+const NEXT_URL = '/next';
+const ISSUES_URL = 'https://github.com/mapbox/geojson.io/issues';
+
+module.exports = function (context) {
+  const dismissedAt = context.storage.get(DISMISS_KEY);
+  if (
+    typeof dismissedAt === 'number' &&
+    Date.now() - dismissedAt < DISMISS_TTL_MS
+  )
+    return;
+
+  const m = modal(d3.select('div.geojsonio'));
+  const content = m.select('.content');
+
+  content
+    .append('div')
+    .attr('class', 'header pad2 fillD')
+    .append('h1')
+    .text('Heads up: geojson.io is changing');
+
+  const body = content.append('div').attr('class', 'pad2');
+
+  body
+    .append('p')
+    .attr('class', 'mb-4')
+    .html(
+      'On <strong>June 1st</strong>, the new geojson.io (currently at ' +
+        '<a href="' +
+        NEXT_URL +
+        '" target="_blank" class="underline">/next</a>) ' +
+        'will replace this version.'
+    );
+
+  body
+    .append('p')
+    .attr('class', 'mb-4')
+    .html(
+      'Found a bug or have feedback on the new version? Please ' +
+        '<a href="' +
+        ISSUES_URL +
+        '" target="_blank" rel="noopener" class="underline">' +
+        'file an issue on GitHub</a>.'
+    );
+
+  const actions = body.append('div').attr('class', 'flex gap-2 mt-4');
+
+  actions
+    .append('a')
+    .attr('href', NEXT_URL)
+    .attr('target', '_blank')
+    .attr(
+      'class',
+      'bg-pink hover:bg-pink-dark text-white text-sm font-bold py-2 px-4 rounded inline-flex items-center gap-2 no-underline'
+    )
+    .html('Try the new geojson.io <span>&rarr;</span>');
+
+  actions
+    .append('a')
+    .attr('href', ISSUES_URL)
+    .attr('target', '_blank')
+    .attr('rel', 'noopener')
+    .attr(
+      'class',
+      'bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-2 px-4 rounded inline-flex items-center no-underline'
+    )
+    .text('File an issue on GitHub');
+
+  // Persist dismissal regardless of how the modal is closed (X, backdrop, ESC).
+  const baseClose = m.close;
+  m.close = function () {
+    context.storage.set(DISMISS_KEY, Date.now());
+    baseClose.call(m);
+  };
+};

--- a/src/ui/cutover_notice.js
+++ b/src/ui/cutover_notice.js
@@ -56,7 +56,21 @@ module.exports = function (context) {
         'file an issue on GitHub</a>.'
     );
 
-  const actions = body.append('div').attr('class', 'flex gap-2 mt-4');
+  const actions = body
+    .append('div')
+    .attr('class', 'flex justify-between gap-2 mt-4');
+
+  actions
+    .append('button')
+    .attr('type', 'button')
+    .attr(
+      'class',
+      'bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-2 px-4 rounded inline-flex items-center no-underline'
+    )
+    .text('Continue to legacy geojson.io')
+    .on('click', () => {
+      m.close();
+    });
 
   actions
     .append('a')
@@ -67,17 +81,6 @@ module.exports = function (context) {
       'bg-pink hover:bg-pink-dark text-white text-sm font-bold py-2 px-4 rounded inline-flex items-center gap-2 no-underline'
     )
     .html('Try the new geojson.io <span>&rarr;</span>');
-
-  actions
-    .append('a')
-    .attr('href', ISSUES_URL)
-    .attr('target', '_blank')
-    .attr('rel', 'noopener')
-    .attr(
-      'class',
-      'bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-bold py-2 px-4 rounded inline-flex items-center no-underline'
-    )
-    .text('File an issue on GitHub');
 
   // Persist dismissal regardless of how the modal is closed (X, backdrop, ESC).
   const baseClose = m.close;


### PR DESCRIPTION
## Summary
- New modal on the legacy D3 app warning users that `/next` becomes the default geojson.io on **June 1, 2026**, with CTAs to try `/next` and file feedback on GitHub Issues.
- Built on the existing `src/ui/modal.js` D3 helper. Wired into `src/index.js` after the UI mounts.
- Dismissals are stored in `localStorage` (`cutover_notice_dismissed_v1`) as a timestamp and expire after **3 days**, so the notice resurfaces closer to cutover without nagging on every visit.


<img width="1435" height="758" alt="Screenshot 2026-05-11 at 3 30 48 PM" src="https://github.com/user-attachments/assets/ecf8d42b-f23a-4d34-95f2-9b3c9f4967a7" />

> [!Warning]
> This PR links to a new Changelog.md file which is going to be released in #970. Merge #970 first.

## Test plan
- [ ] Load the legacy app fresh (no prior dismissal) — modal appears with headline, body copy, GitHub issues link, and pink "Try the new geojson.io" CTA.
- [ ] Dismiss via the X button — modal closes; `localStorage.getItem('cutover_notice_dismissed_v1')` is a numeric timestamp.
- [ ] Reload — modal does **not** reappear.
- [ ] Set `localStorage.setItem('cutover_notice_dismissed_v1', String(Date.now() - 4*24*60*60*1000))` and reload — modal reappears (TTL expiry).
- [ ] "File an issue on GitHub" opens https://github.com/mapbox/geojson.io/issues in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)