### PR TITLE
Adds Changelog section to About modal

### DIFF
--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -4,7 +4,7 @@ Recent changes to the geojson.io application. Entries are grouped by ship date.
 
 ## 2026-05-05
 
-- **Feature editor:** Collapsible UI in the Feature Editor for working with large property sets ([#965](https://github.com/mapbox/geojson.io/pull/965))
+- **Feature editor:** Collapsible UI in the Feature Editor to reduce visual clutter when not using Selected Feature editor ([#965](https://github.com/mapbox/geojson.io/pull/965))
 - **URL sharing:** Support legacy hash-based `#data=` URLs and strip query params from the URL after data loads ([#966](https://github.com/mapbox/geojson.io/pull/966))
 
 ## 2026-05-04
@@ -17,7 +17,7 @@ Recent changes to the geojson.io application. Entries are grouped by ship date.
 
 ## 2026-04-20
 
-- **Map controls:** Pitch and bearing support for tilted/rotated map views
+- **Pitch & Rotation:** Pitch and rotation/bearing support for tilted/rotated map views
 - **Left panel:** Default starter state with helpful links to supported file types ([#962](https://github.com/mapbox/geojson.io/pull/962))
 - **Basemap:** Restored OpenStreetMap basemap option
 

--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+Recent changes to the geojson.io application. Entries are grouped by ship date.
+
+## 2026-05-05
+
+- **Feature editor:** Collapsible UI in the Feature Editor for working with large property sets ([#965](https://github.com/mapbox/geojson.io/pull/965))
+- **URL sharing:** Support legacy hash-based `#data=` URLs and strip query params from the URL after data loads ([#966](https://github.com/mapbox/geojson.io/pull/966))
+
+## 2026-05-04
+
+- **Keyboard shortcuts:** Localized keybinding hints for Mac vs. Windows/Linux ([#968](https://github.com/mapbox/geojson.io/pull/968))
+
+## 2026-04-21
+
+- **Custom raster layers:** Add, edit, reorder, and toggle visibility of your own raster tile layers ([#963](https://github.com/mapbox/geojson.io/pull/963))
+
+## 2026-04-20
+
+- **Map controls:** Pitch and bearing support for tilted/rotated map views
+- **Left panel:** Default starter state with helpful links to supported file types ([#962](https://github.com/mapbox/geojson.io/pull/962))
+- **Basemap:** Restored OpenStreetMap basemap option
+
+## 2026-04-02
+
+- **Simple style markers:** Render and edit `marker-color`, `marker-symbol`, and `marker-size` properties on point features ([#961](https://github.com/mapbox/geojson.io/pull/961))
+
+## 2026-02-27
+
+- **Drawing:** Fixed an extra coordinate being added when finishing polygons
+
+## 2026-02-12
+
+- **Reliability:** Fixed history (undo/redo) creation in some edit flows ([#948](https://github.com/mapbox/geojson.io/pull/948))
+- Internal analytics added to the new app
+
+## 2026-02-11
+
+- **Rendering:** Fixed black circles on the dark basemap
+- **Mobile:** Restored vertical layout on small screens
+
+## 2026-01-16
+
+- **UI:** "Zoom to all" is now disabled when there are no features ([#942](https://github.com/mapbox/geojson.io/pull/942))
+- **Rendering:** Fixed deck.gl circle offset when using the Standard style ([#943](https://github.com/mapbox/geojson.io/pull/943))
+
+## 2026-01-13
+
+- Initial deployment of the new geojson.io at the `/next` path

--- a/next/app/components/about_modal.tsx
+++ b/next/app/components/about_modal.tsx
@@ -7,6 +7,7 @@ import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import { DialogHeader } from 'app/components/dialog';
 import { getIsMac, localizeKeybinding } from 'app/lib/utils';
+import { changelogForAboutModal } from 'state/changelog';
 
 // Utility to extract headings from markdown
 function extractHeadings(markdown: string) {
@@ -42,14 +43,14 @@ export default function AboutModal({ open }: { open: boolean }) {
   const headingRefs = useRef<Record<string, HTMLHeadingElement | null>>({});
   const [activeHeading, setActiveHeading] = useState<string | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
-
   useEffect(() => {
     if (open) {
       fetch('/next/about.md')
         .then((res) => res.text())
         .then((md) => {
-          setMarkdown(localizeMarkdown(md));
-          setHeadings(extractHeadings(md));
+          const combined = `${md}\n\n${changelogForAboutModal}`;
+          setMarkdown(localizeMarkdown(combined));
+          setHeadings(extractHeadings(combined));
         })
         .catch(() => setMarkdown('Failed to load info.'));
     }

--- a/next/state/changelog.ts
+++ b/next/state/changelog.ts
@@ -16,5 +16,5 @@ export const changelogForAboutModal: string = (() => {
     .join('')
     .replace(/^##\s+(\d{4}-\d{2}-\d{2})\s*$/gm, '**$1**')
     .trim();
-  return `## What's new\n\n${recent}\n\n[View full changelog on GitHub →](${FULL_CHANGELOG_URL})\n`;
+  return `## Changelog\n\n${recent}\n\n[View full changelog on GitHub →](${FULL_CHANGELOG_URL})\n`;
 })();

--- a/next/state/changelog.ts
+++ b/next/state/changelog.ts
@@ -1,0 +1,20 @@
+import changelogMarkdown from '../CHANGELOG.md?raw';
+
+const RECENT_ENTRY_COUNT = 5;
+const FULL_CHANGELOG_URL =
+  'https://github.com/mapbox/geojson.io/blob/main/next/CHANGELOG.md';
+
+// Reformats the standalone CHANGELOG.md to embed cleanly in the About modal:
+// keep the most recent N date entries, demote each date heading to inline
+// bold text so the sidebar nav stays tidy, prepend a "What's new" heading,
+// and link out to the full changelog on GitHub.
+export const changelogForAboutModal: string = (() => {
+  const sections = changelogMarkdown.split(/(?=^##\s+\d{4}-\d{2}-\d{2})/m);
+  const dated = sections.filter((s) => /^##\s+\d{4}-\d{2}-\d{2}/.test(s));
+  const recent = dated
+    .slice(0, RECENT_ENTRY_COUNT)
+    .join('')
+    .replace(/^##\s+(\d{4}-\d{2}-\d{2})\s*$/gm, '**$1**')
+    .trim();
+  return `## What's new\n\n${recent}\n\n[View full changelog on GitHub →](${FULL_CHANGELOG_URL})\n`;
+})();


### PR DESCRIPTION
## Summary
- Introduces a date-based `next/CHANGELOG.md` for the /next app, backfilled from recent /next-touching commits (Jan 2026 → May 2026). No version numbers — date-based is the right fit for an app, not a package.
- Adds a "Changelog" section at the bottom of the About modal sidebar that renders the **most recent 5 date entries** with a link out to the full changelog on GitHub.
- New module `next/state/changelog.ts` imports the markdown via Vite `?raw` (build-time, no runtime fetch), trims to the 5 most recent entries, demotes each `## YYYY-MM-DD` to inline bold so the sidebar nav stays a single "Changelog" entry.
<img width="1415" height="749" alt="Screenshot 2026-05-11 at 3 37 16 PM" src="https://github.com/user-attachments/assets/ab1266cd-0439-433b-8652-0b4a2459a529" />


## Notes
- `RECENT_ENTRY_COUNT = 5` in `next/state/changelog.ts` — tune there.
- The changelog is bundled into the initial JS (about_modal is imported eagerly by dialogs.tsx). Total cost is ~2KB of inlined markdown plus a one-time parse.
- Maintenance: add new entries to the top of `next/CHANGELOG.md` under a new `## YYYY-MM-DD` heading and they automatically appear in the modal.

## Test plan
- [ ] `cd next && npm run dev`, open `/next`, click the info icon — About modal opens.
- [ ] Sidebar nav shows existing sections plus "Changelog" as the **last** entry.
- [ ] Scrolling to (or clicking) "Changelog" reveals the most recent 5 entries, each with a bold date label and bullet points.
- [ ] Bottom of the section has a "View full changelog on GitHub →" link that opens the full `next/CHANGELOG.md` on GitHub.
- [ ] Edit `next/CHANGELOG.md` locally — add a new `## YYYY-MM-DD` block at the top — refresh and confirm it shows in the modal and the oldest entry rolls off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)