### PR TITLE
Add globe atmosphere and stars to OSM and Outdoors styles

### DIFF
--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent changes to the geojson.io application. Entries are grouped by ship date.
 
+## 2026-06-28
+
+- **Add fog to non-standard styles:** Adds fog to the OSM and Outdoors basemaps for consistency across all basemap options. ([#980](https://github.com/mapbox/geojson.io/pull/980))
+
+## 2026-06-27
+
+- **Add globe projection and 3d features toggle:** Adds a toggle to switch between globe and mercator projections and to toggle 3d features on basemaps that support them. ([#975](https://github.com/mapbox/geojson.io/pull/975))
+
 ## 2026-05-12
 
 - **Persist Camera View:** Camera options (map view) are persisted in sessionStorage and are available via query params for sharing specific views ([#967](https://github.com/mapbox/geojson.io/pull/967))

--- a/next/app/lib/standard_fog.ts
+++ b/next/app/lib/standard_fog.ts
@@ -1,0 +1,139 @@
+/**
+ * Fog/atmosphere definition from the Mapbox Standard style.
+ * Apply this to non-Standard styles (e.g. Outdoors, OSM) to get
+ * stars and atmospheric haze in globe projection.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const STANDARD_FOG: Record<string, any> = {
+  'vertical-range': [30, 120],
+  range: [
+    'interpolate',
+    ['linear'],
+    ['zoom'],
+    13,
+    ['literal', [1, 10]],
+    15,
+    ['literal', [1, 4]],
+    22,
+    ['literal', [14, 20]]
+  ],
+  color: [
+    'interpolate',
+    ['exponential', 1.2],
+    ['zoom'],
+    5,
+    [
+      'interpolate',
+      ['linear'],
+      ['measure-light', 'brightness'],
+      0.1,
+      'hsla(240, 9%, 55%, 1)',
+      0.4,
+      'hsla(0, 0%, 100%, 1)'
+    ],
+    7,
+    [
+      'interpolate',
+      ['linear'],
+      ['measure-light', 'brightness'],
+      0.02,
+      'hsla(213, 63%, 20%, 0.9)',
+      0.03,
+      'hsla(30, 65%, 60%, 0.5)',
+      0.4,
+      'hsla(10, 79%, 88%, 0.95)',
+      0.45,
+      'hsla(200, 60%, 98%, 0.9)'
+    ]
+  ],
+  'high-color': [
+    'interpolate',
+    ['exponential', 1.2],
+    ['zoom'],
+    5,
+    [
+      'interpolate',
+      ['linear'],
+      ['measure-light', 'brightness'],
+      0.1,
+      'hsla(215, 100%, 20%, 1)',
+      0.4,
+      'hsla(215, 100%, 51%, 1)'
+    ],
+    7,
+    [
+      'interpolate',
+      ['linear'],
+      ['measure-light', 'brightness'],
+      0,
+      'hsla(228, 38%, 20%, 1)',
+      0.05,
+      'hsla(360, 100%, 85%, 1)',
+      0.2,
+      'hsla(205, 88%, 86%, 1)',
+      0.4,
+      'hsla(270, 65%, 85%, 1)',
+      0.45,
+      'hsla(0, 0%, 100%, 1)'
+    ]
+  ],
+  'space-color': [
+    'interpolate',
+    ['exponential', 1.2],
+    ['zoom'],
+    5,
+    'hsl(211, 84%, 9%)',
+    7,
+    [
+      'interpolate',
+      ['linear'],
+      ['measure-light', 'brightness'],
+      0,
+      'hsl(211, 84%, 17%)',
+      0.2,
+      'hsl(210, 40%, 30%)',
+      0.4,
+      'hsl(270, 45%, 98%)',
+      0.45,
+      'hsl(210, 100%, 80%)'
+    ]
+  ],
+  'horizon-blend': [
+    'interpolate',
+    ['exponential', 1.2],
+    ['zoom'],
+    5,
+    0.01,
+    7,
+    [
+      'interpolate',
+      ['exponential', 1.2],
+      ['measure-light', 'brightness'],
+      0.35,
+      0.03,
+      0.4,
+      0.1,
+      0.45,
+      0.03
+    ]
+  ],
+  'star-intensity': [
+    'interpolate',
+    ['exponential', 1.2],
+    ['zoom'],
+    5,
+    0.4,
+    7,
+    [
+      'interpolate',
+      ['exponential', 1.2],
+      ['measure-light', 'brightness'],
+      0.1,
+      0.2,
+      0.3,
+      0
+    ]
+  ]
+};
+
+export default STANDARD_FOG;

--- a/next/app/lib/style_config_adapters.ts
+++ b/next/app/lib/style_config_adapters.ts
@@ -1,4 +1,5 @@
 import { getMapboxLayerURL } from 'app/lib/utils';
+import STANDARD_FOG from 'app/lib/standard_fog';
 import once from 'lodash/once';
 import mapboxgl from 'mapbox-gl';
 import { toast } from 'react-hot-toast';
@@ -183,6 +184,11 @@ function updateMapboxStyle(
   };
   if (typeof updatedImports !== 'undefined') {
     result.imports = updatedImports;
+  }
+  // Apply Standard fog to non-import styles (OSM, Outdoors) so they get
+  // stars and atmospheric haze when in globe projection.
+  if (!style.imports) {
+    result.fog = STANDARD_FOG;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Adds fog to the OSM and Outdoors styles so they don't have the empty white background when in globe view. Contains work downstream of #975, which should be merged first.

- Extracts the `fog` property from the Mapbox Standard style and saves it as `app/lib/standard_fog.ts`
- Applies the fog to all non-import styles (OSM, Outdoors) in `updateMapboxStyle`, giving them atmospheric haze and star rendering when globe projection is active
- Simplified the fog expressions by dropping `['config', 'theme']` / monochrome branches, which are only meaningful inside a Standard style import context

<img width="1419" height="780" alt="image" src="https://github.com/user-attachments/assets/3995d5a9-2559-4e58-af33-fc1db5868fcf" />
