### PR TITLE
Add Mobile Meta Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 Recent changes to the geojson.io application. Entries are grouped by ship date.
 
-## 2026-06-28
+## 2026-06-01
+
+- **Add Mobile Meta viewport Tag** - Fix for browsers properly handling mobile viewports.
+
+## 2026-05-28
 
 - **Add fog to non-standard styles:** Adds fog to the OSM and Outdoors basemaps for consistency across all basemap options. ([#980](https://github.com/mapbox/geojson.io/pull/980))
 
-## 2026-06-27
+## 2026-05-27
 
 - **Add globe projection and 3d features toggle:** Adds a toggle to switch between globe and mercator projections and to toggle 3d features on basemaps that support them. ([#975](https://github.com/mapbox/geojson.io/pull/975))
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="application-name" content="geojson.io" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
This PR adds the standard mobile viewport meta tag to the app entry point to make sure browsers enable CSS responsive layouts.
