### PR TITLE
Support TMS tile URLs with {-y} and require https://

### DIFF
--- a/app/components/dialogs/raster_layer.tsx
+++ b/app/components/dialogs/raster_layer.tsx
@@ -15,9 +15,16 @@ interface RasterLayerFormValues {
   tileUrl: string;
 }
 
-function validateTileUrl(url: string): boolean {
-  // Check if the URL contains {z}, {x}, and {y} placeholders
-  return url.includes('{z}') && url.includes('{x}') && url.includes('{y}');
+function validateTileUrl(url: string): string | undefined {
+  if (!url.startsWith('https://')) return 'URL must start with https://';
+  // Accept {y} (XYZ scheme) or {-y} (TMS scheme, flipped Y axis)
+  if (
+    !url.includes('{z}') ||
+    !url.includes('{x}') ||
+    (!url.includes('{y}') && !url.includes('{-y}'))
+  ) {
+    return 'Must include {z}, {x}, and {y} (or {-y} for TMS) placeholders';
+  }
 }
 
 export function RasterLayerDialog({
@@ -59,8 +66,9 @@ export function RasterLayerDialog({
 
           if (!values.tileUrl.trim()) {
             errors.tileUrl = 'Tile URL is required';
-          } else if (!validateTileUrl(values.tileUrl)) {
-            errors.tileUrl = 'Must include {z}, {x}, and {y} placeholders';
+          } else {
+            const urlError = validateTileUrl(values.tileUrl);
+            if (urlError) errors.tileUrl = urlError;
           }
 
           return errors;
@@ -112,8 +120,10 @@ export function RasterLayerDialog({
               placeholder="https://example.com/tiles/{z}/{x}/{y}.png"
             />
             <TextWell>
-              Provide a tile URL template with {'{z}'}, {'{x}'}, and {'{y}'}{' '}
-              placeholders for zoom level and tile coordinates.
+              Provide a tile URL template starting with https:// and including{' '}
+              {'{z}'}, {'{x}'}, and {'{y}'} placeholders for zoom level and tile
+              coordinates. Use {'{-y}'} instead of {'{y}'} for TMS layers with a
+              flipped Y axis (e.g. from JOSM or QGIS).
             </TextWell>
             <TextWell>
               <strong>Note:</strong> Your raster layer configuration will be

--- a/app/components/dialogs/raster_layer.tsx
+++ b/app/components/dialogs/raster_layer.tsx
@@ -16,7 +16,10 @@ interface RasterLayerFormValues {
 }
 
 function validateTileUrl(url: string): string | undefined {
-  if (!url.startsWith('https://')) return 'URL must start with https://';
+  const isLocal = url.includes('localhost') || url.includes('127.0.0.1');
+  if (!url.startsWith('https://') && !(isLocal && url.startsWith('http://'))) {
+    return 'URL must start with https://';
+  }
   // Accept {y} (XYZ scheme) or {-y} (TMS scheme, flipped Y axis)
   if (
     !url.includes('{z}') ||
@@ -120,10 +123,11 @@ export function RasterLayerDialog({
               placeholder="https://example.com/tiles/{z}/{x}/{y}.png"
             />
             <TextWell>
-              Provide a tile URL template starting with https:// and including{' '}
-              {'{z}'}, {'{x}'}, and {'{y}'} placeholders for zoom level and tile
-              coordinates. Use {'{-y}'} instead of {'{y}'} for TMS layers with a
-              flipped Y axis (e.g. from JOSM or QGIS).
+              Provide a tile URL template starting with https:// (or http:// for
+              localhost) and including {'{z}'}, {'{x}'}, and {'{y}'}{' '}
+              placeholders for zoom level and tile coordinates. Use {'{-y}'}{' '}
+              instead of {'{y}'} for TMS layers with a flipped Y axis (e.g. from
+              JOSM or QGIS).
             </TextWell>
             <TextWell>
               <strong>Note:</strong> Your raster layer configuration will be

--- a/app/lib/style_config_adapters.ts
+++ b/app/lib/style_config_adapters.ts
@@ -79,10 +79,15 @@ function updateMapboxStyle(
     (layer) => layer.visible !== false
   );
   visibleCustomRasterLayers.forEach((layer) => {
+    const isTms = layer.tileUrl.includes('{-y}');
+    const tiles = [
+      isTms ? layer.tileUrl.replace('{-y}', '{y}') : layer.tileUrl
+    ];
     updatedSources[`custom-raster-${layer.id}`] = {
       type: 'raster',
-      tiles: [layer.tileUrl],
-      tileSize: 256
+      tiles,
+      tileSize: 256,
+      ...(isTms ? { scheme: 'tms' } : {})
     } as mapboxgl.RasterSource;
   });
 


### PR DESCRIPTION
## Summary

- Accepts `{-y}` in raster tile URL templates, the TMS flipped-Y convention used by JOSM, QGIS, and others. Mapbox GL JS doesn't understand `{-y}` natively, so it's replaced with `{y}` and `scheme: 'tms'` is set on the source, which tells Mapbox GL JS to flip the Y axis internally.
- Requires `https://` in tile URL validation unless the URL contains localhost or 127.0.0.1 — the Add/Update button stays disabled until the URL is valid (http:// tiles are blocked by browsers on an HTTPS page anyway).
- Updated hint text documents both `{-y}` support and the https requirement.

Closes #990 

## Test plan

- [x] Enter an `http://` URL — button should remain disabled with error "URL must start with https://"
- [x] Enter an `http://` URL with localhost or 127.0.0.1 and the correct z/x/y placeholders — button enables, layer loads correctly
- [ ] Enter a valid `https://` URL missing placeholders — button disabled with placeholder error
- [x] Enter a valid XYZ URL (`https://.../{z}/{x}/{y}.png`) — button enables, layer loads correctly
- [x] Enter a TMS URL with `{-y}` (`https://tms.osm-hr.org/karlovac-2023/{z}/{x}/{-y}.png`) — button enables, tiles render with correct origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)