### PR TITLE
Feature updates based on User Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Recent changes to the geojson.io application. Entries are grouped by ship date.
 
+## 2026-06-04
+
+- **Delete all features:** Adds a delete all button to the feature editor header. Operation is undoable via Ctrl-Z. ([#993](https://github.com/mapbox/geojson.io/pull/993))
+- **Numpad Delete key fix:** The Delete key on numpads (numlock off) now correctly deletes selected features. ([#993](https://github.com/mapbox/geojson.io/pull/993))
+- **Map URL coordinate precision:** Increased lat/lng precision in the `?map=` query param from 2 to 4 decimal places. ([#993](https://github.com/mapbox/geojson.io/pull/993))
+- **GeoJSON editor fold gutter:** Adds a fold gutter to the GeoJSON editor panel for collapsing nested objects and arrays. ([#993](https://github.com/mapbox/geojson.io/pull/993))
+- **GL JS Update:** Bump to `v3.24.0` [#992](https://github.com/mapbox/geojson.io/pull/992)
+- **Replace Standard Light and Dark with Classic Light/Dark:** Removes light and dark themes based on Mapbox Standard for `light-v11` and `dark-v11` for faster performance by default. [#992](https://github.com/mapbox/geojson.io/pull/992)
+- **TMS Support for inverted -y**: Adds support for TMS raster tileset URLs which use an inverted y in the url `...{z}/{x}/{-y}.png` [#991](https://github.com/mapbox/geojson.io/pull/991)
+
 ## 2026-06-01
 
 - **Add Mobile Meta viewport Tag** - Fix for browsers properly handling mobile viewports.

--- a/app/components/panels/feature_editor/feature_editor_folder/header.tsx
+++ b/app/components/panels/feature_editor/feature_editor_folder/header.tsx
@@ -76,9 +76,19 @@ export function FeatureEditorFolderHeader({
           deleteFeatures: allIds
         });
         // UI notif with fallback note
-        toast('All features deleted:', {
-          icon: '👏'
-        });
+        toast.success(
+          (t) => (
+            <div>
+              <p>
+                <strong>All features deleted.</strong>
+              </p>
+              <p>
+                Use <pre style={{ display: 'inline' }}>Ctrl-z</pre> to undo.
+              </p>
+            </div>
+          ),
+          { duration: 2000 }
+        );
       },
       [transact]
     )

--- a/app/components/panels/feature_editor/feature_editor_folder/header.tsx
+++ b/app/components/panels/feature_editor/feature_editor_folder/header.tsx
@@ -1,4 +1,8 @@
-import { CaretDownIcon, Crosshair1Icon } from '@radix-ui/react-icons';
+import {
+  CaretDownIcon,
+  Crosshair1Icon,
+  TrashIcon
+} from '@radix-ui/react-icons';
 import {
   Button,
   StyledLabelSpan,
@@ -13,6 +17,11 @@ import { usePersistence } from 'app/lib/persistence/context';
 import { useZoomTo } from 'app/hooks/use_zoom_to';
 import { Popover as P, Tooltip } from 'radix-ui';
 import type { FeatureMap } from 'types';
+import { useCallback } from 'react';
+import { dataAtom } from 'state/jotai';
+import { useAtomCallback } from 'jotai/utils';
+import { EMPTY_MOMENT } from 'app/lib/persistence/moment';
+import { toast } from 'react-hot-toast';
 
 function PreviewProperty({ featureMap }: { featureMap: FeatureMap }) {
   const rep = usePersistence();
@@ -53,6 +62,27 @@ export function FeatureEditorFolderHeader({
   const rep = usePersistence();
   const [meta] = rep.useMetadata();
   const zoomTo = useZoomTo();
+  const transact = rep.useTransact();
+
+  const handleDeleteAll = useAtomCallback(
+    useCallback(
+      async (get) => {
+        const data = get(dataAtom);
+        const allIds = Array.from(data.featureMap.keys());
+        if (allIds.length === 0) return;
+        await transact({
+          ...EMPTY_MOMENT,
+          note: 'Deleted all features',
+          deleteFeatures: allIds
+        });
+        // UI notif with fallback note
+        toast('All features deleted:', {
+          icon: '👏'
+        });
+      },
+      [transact]
+    )
+  );
 
   const handleZoomToAll = () => {
     const allFeatures = Array.from(featureMap.values());
@@ -75,18 +105,34 @@ export function FeatureEditorFolderHeader({
           <PreviewProperty featureMap={featureMap} />
         </StyledPopoverContent>
       </P.Root>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <Button
-            onClick={handleZoomToAll}
-            size="xs"
-            disabled={featureMap.size === 0}
-          >
-            <Crosshair1Icon />
-          </Button>
-        </Tooltip.Trigger>
-        <TContent side="bottom">Zoom to all</TContent>
-      </Tooltip.Root>
+      <div>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <Button
+              className="mr-3"
+              onClick={handleZoomToAll}
+              size="xs"
+              disabled={featureMap.size === 0}
+            >
+              <Crosshair1Icon />
+            </Button>
+          </Tooltip.Trigger>
+          <TContent side="bottom">Zoom to all</TContent>
+        </Tooltip.Root>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <Button
+              onClick={handleDeleteAll}
+              size="xs"
+              disabled={featureMap.size === 0}
+            >
+              <TrashIcon />
+            </Button>
+          </Tooltip.Trigger>
+          <TContent side="bottom">Delete all features</TContent>
+        </Tooltip.Root>
+      </div>
     </div>
   );
 }

--- a/app/components/panels/geojson_editor.tsx
+++ b/app/components/panels/geojson_editor.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { EditorState, Transaction } from '@codemirror/state';
 import { EditorView, lineNumbers } from '@codemirror/view';
+import { foldGutter } from '@codemirror/language';
 import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
 import { Button } from 'app/components/elements';
@@ -76,6 +77,7 @@ export function GeoJSONEditor({
       checker,
       lintGutter(),
       lineNumbers(),
+      foldGutter(),
       preventDrop
     ],
     [preventDrop]

--- a/app/hooks/use_map_keybindings.ts
+++ b/app/hooks/use_map_keybindings.ts
@@ -132,7 +132,7 @@ export function useMapKeybindings() {
       e.preventDefault();
       void onDelete();
     },
-    keybindingOptions,
+    { ...keybindingOptions, useKey: true },
     [onDelete]
   );
 }

--- a/app/lib/parse_map_param.test.ts
+++ b/app/lib/parse_map_param.test.ts
@@ -155,16 +155,16 @@ describe('serializeMapParam', () => {
     ).toBe('9.12/40/-73');
   });
 
-  it('rounds lat/lng to 2 decimal places', () => {
+  it('rounds lat/lng to 5 decimal places', () => {
     expect(
       serializeMapParam({
         zoom: 10,
-        lat: 40.12789,
-        lng: -73.98654,
+        lat: 40.12789817,
+        lng: -73.9865419238,
         bearing: 0,
         pitch: 0
       })
-    ).toBe('10/40.13/-73.99');
+    ).toBe('10/40.1279/-73.98654');
   });
 
   it('rounds bearing to 1 decimal place', () => {

--- a/app/lib/parse_map_param.ts
+++ b/app/lib/parse_map_param.ts
@@ -49,8 +49,8 @@ export function serializeMapParam(camera: CameraPosition): string {
 
   const parts: number[] = [
     round(camera.zoom, 2),
-    round(camera.lat, 2),
-    round(camera.lng, 2)
+    round(camera.lat, 5),
+    round(camera.lng, 5)
   ];
 
   if (bearing !== 0 || pitch !== 0) {


### PR DESCRIPTION
## Summary

### Delete all / Clear  features button
adds a trash icon button to the feature editor header that  deletes all features on the map in a single click. Uses the same atomic state update and undo moment as the keyboard delete flow, so the operation is fully undoable. A toast notification  reminds the user they can undo with Ctrl-Z.

<img width="637" height="448" alt="Screenshot 2026-06-04 at 2 34 19 PM" src="https://github.com/user-attachments/assets/d38ce6fd-557c-41c1-8a47-f1a74653b47f" />

Closes #978 

### Numpad Delete key fix 
the Delete key on the numpad (numlock off) was not triggering feature deletion. Root cause: react-hotkeys-hook defaults to matching on event.code (physical key position), and the numpad Delete has code NumpadDecimal rather than Delete. Fixed by passing  useKey: true for the delete binding so it matches on event.key (logical value) instead — both keys produce key: "Delete" when numlock is off.

Closes #982 

### Increased map URL coordinate precision
Lat/lng in the ?map= query param were rounded to 2 decimal places (~1km precision). Increased to 4 decimal places (~11m) to match the precision of  the legacy app's Mapbox GL hash. Reported by users who regularly use Geojson.io to debugging geometry in multiple tools which rely on this coordinate precision
 
### CodeMirror fold gutter — 
Adds a `foldGutter()` extension to CodeMirror affecting the GeoJSON editor so users can collapse nested  objects and arrays in the JSON panel.

Closes #988 





