### PR TITLE
Add radius tooltip, center point, and dashed radius line when drawing/resizing circles

### DIFF
--- a/app/components/map_component.tsx
+++ b/app/components/map_component.tsx
@@ -28,6 +28,7 @@ import {
 import {
   cursorStyleAtom,
   dataAtom,
+  drawCursorLabelAtom,
   ephemeralStateAtom,
   styleConfigAtom,
   Mode,
@@ -102,6 +103,7 @@ export const MapComponent = memo(function MapComponent({
   const ephemeralState = useAtomValue(ephemeralStateAtom);
   const mode = useAtomValue(modeAtom);
   const [cursor, setCursor] = useAtom(cursorStyleAtom);
+  const drawCursorLabel = useAtomValue(drawCursorLabelAtom);
 
   // Refs
   const mapRef: React.MutableRefObject<PMap | null> = useRef<PMap>(null);
@@ -452,6 +454,17 @@ export const MapComponent = memo(function MapComponent({
       <MapContextMenu contextInfo={contextInfo} />
       <LastSearchResult />
       <ModeHints />
+      {drawCursorLabel && (
+        <div
+          className="absolute z-10 pointer-events-none px-2 py-1 rounded text-xs bg-white dark:bg-gray-800 dark:text-white shadow whitespace-nowrap"
+          style={{
+            left: drawCursorLabel.x + 12,
+            top: drawCursorLabel.y + 12
+          }}
+        >
+          {drawCursorLabel.text}
+        </div>
+      )}
     </CM.Root>
   );
 });

--- a/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
+++ b/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
@@ -544,9 +544,53 @@ exports[`loadAndAugmentStyle 1`] = `
       "source": "features",
       "type": "symbol",
     },
+    {
+      "filter": [
+        "==",
+        "$type",
+        "LineString",
+      ],
+      "id": "circle-drawing-line",
+      "paint": {
+        "line-color": "#3195ff",
+        "line-dasharray": [
+          4,
+          3,
+        ],
+        "line-emissive-strength": 1,
+        "line-width": 1.5,
+      },
+      "source": "circle-drawing",
+      "type": "line",
+    },
+    {
+      "filter": [
+        "==",
+        "$type",
+        "Point",
+      ],
+      "id": "circle-drawing-center",
+      "layout": {},
+      "paint": {
+        "circle-color": "white",
+        "circle-emissive-strength": 1,
+        "circle-radius": 5,
+        "circle-stroke-color": "#3195ff",
+        "circle-stroke-width": 2,
+      },
+      "source": "circle-drawing",
+      "type": "circle",
+    },
   ],
   "name": "Empty",
   "sources": {
+    "circle-drawing": {
+      "data": {
+        "features": [],
+        "type": "FeatureCollection",
+      },
+      "type": "geojson",
+    },
     "ephemeral": {
       "buffer": 4,
       "data": {
@@ -1070,6 +1114,43 @@ exports[`makeLayers > categorical 2`] = `
     "source": "features",
     "type": "symbol",
   },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "LineString",
+    ],
+    "id": "circle-drawing-line",
+    "paint": {
+      "line-color": "#3195ff",
+      "line-dasharray": [
+        4,
+        3,
+      ],
+      "line-emissive-strength": 1,
+      "line-width": 1.5,
+    },
+    "source": "circle-drawing",
+    "type": "line",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "Point",
+    ],
+    "id": "circle-drawing-center",
+    "layout": {},
+    "paint": {
+      "circle-color": "white",
+      "circle-emissive-strength": 1,
+      "circle-radius": 5,
+      "circle-stroke-color": "#3195ff",
+      "circle-stroke-width": 2,
+    },
+    "source": "circle-drawing",
+    "type": "circle",
+  },
 ]
 `;
 
@@ -1586,6 +1667,43 @@ exports[`makeLayers > none 1`] = `
     "source": "features",
     "type": "symbol",
   },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "LineString",
+    ],
+    "id": "circle-drawing-line",
+    "paint": {
+      "line-color": "#3195ff",
+      "line-dasharray": [
+        4,
+        3,
+      ],
+      "line-emissive-strength": 1,
+      "line-width": 1.5,
+    },
+    "source": "circle-drawing",
+    "type": "line",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "Point",
+    ],
+    "id": "circle-drawing-center",
+    "layout": {},
+    "paint": {
+      "circle-color": "white",
+      "circle-emissive-strength": 1,
+      "circle-radius": 5,
+      "circle-stroke-color": "#3195ff",
+      "circle-stroke-width": 2,
+    },
+    "source": "circle-drawing",
+    "type": "circle",
+  },
 ]
 `;
 
@@ -2062,6 +2180,43 @@ exports[`makeLayers > ramp 1`] = `
     },
     "source": "features",
     "type": "symbol",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "LineString",
+    ],
+    "id": "circle-drawing-line",
+    "paint": {
+      "line-color": "#3195ff",
+      "line-dasharray": [
+        4,
+        3,
+      ],
+      "line-emissive-strength": 1,
+      "line-width": 1.5,
+    },
+    "source": "circle-drawing",
+    "type": "line",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "Point",
+    ],
+    "id": "circle-drawing-center",
+    "layout": {},
+    "paint": {
+      "circle-color": "white",
+      "circle-emissive-strength": 1,
+      "circle-radius": 5,
+      "circle-stroke-color": "#3195ff",
+      "circle-stroke-width": 2,
+    },
+    "source": "circle-drawing",
+    "type": "circle",
   },
 ]
 `;
@@ -2584,6 +2739,43 @@ exports[`makeLayers > with preview property 1`] = `
     },
     "source": "features",
     "type": "symbol",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "LineString",
+    ],
+    "id": "circle-drawing-line",
+    "paint": {
+      "line-color": "#3195ff",
+      "line-dasharray": [
+        4,
+        3,
+      ],
+      "line-emissive-strength": 1,
+      "line-width": 1.5,
+    },
+    "source": "circle-drawing",
+    "type": "line",
+  },
+  {
+    "filter": [
+      "==",
+      "$type",
+      "Point",
+    ],
+    "id": "circle-drawing-center",
+    "layout": {},
+    "paint": {
+      "circle-color": "white",
+      "circle-emissive-strength": 1,
+      "circle-radius": 5,
+      "circle-stroke-color": "#3195ff",
+      "circle-stroke-width": 2,
+    },
+    "source": "circle-drawing",
+    "type": "circle",
   },
   {
     "filter": [

--- a/app/lib/circle.ts
+++ b/app/lib/circle.ts
@@ -288,3 +288,28 @@ export function getCircleProp(feature: Feature) {
   if (!prop.success) return null;
   return prop.data['@circle'];
 }
+
+export function getRadiusDisplayText(
+  center: Pos2,
+  mouse: Pos2,
+  type: CIRCLE_TYPE
+): string {
+  switch (type) {
+    case CIRCLE_TYPE.MERCATOR: {
+      const meters = distanceInMercatorMeters(center, mouse);
+      return `${Math.round(meters)} Mercator m`;
+    }
+    case CIRCLE_TYPE.GEODESIC: {
+      const radians = distanceInRadians(center, mouse);
+      const km = radians * 6371;
+      const miles = km * 0.621371;
+      if (km < 1) {
+        return `${Math.round(km * 1000)} m / ${Math.round(miles * 5280)} ft`;
+      }
+      return `${km.toFixed(2)} km / ${miles.toFixed(2)} mi`;
+    }
+    case CIRCLE_TYPE.DEGREES: {
+      return `${distanceInDegrees(center, mouse).toFixed(4)}°`;
+    }
+  }
+}

--- a/app/lib/circle.ts
+++ b/app/lib/circle.ts
@@ -297,7 +297,7 @@ export function getRadiusDisplayText(
   switch (type) {
     case CIRCLE_TYPE.MERCATOR: {
       const meters = distanceInMercatorMeters(center, mouse);
-      return `${Math.round(meters)} Mercator m`;
+      return `${Math.round(meters)} m`;
     }
     case CIRCLE_TYPE.GEODESIC: {
       const radians = distanceInRadians(center, mouse);

--- a/app/lib/handlers/circle.ts
+++ b/app/lib/handlers/circle.ts
@@ -1,12 +1,22 @@
 import { MapContext } from 'app/context/map_context';
-import { type ICircleProp, makeCircle } from 'app/lib/circle';
+import {
+  type ICircleProp,
+  makeCircle,
+  getRadiusDisplayText
+} from 'app/lib/circle';
 import { isRectangleNonzero } from 'app/lib/geometry';
 import { useSetAtom } from 'jotai';
 import noop from 'lodash/noop';
 import { useContext, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { USelection } from 'state';
-import { cursorStyleAtom, Mode, modeAtom, selectionAtom } from 'state/jotai';
+import {
+  cursorStyleAtom,
+  drawCursorLabelAtom,
+  Mode,
+  modeAtom,
+  selectionAtom
+} from 'state/jotai';
 import { CIRCLE_TYPE } from 'state/mode';
 import type { HandlerContext, IFeature, Polygon, Position } from 'types';
 import { createOrUpdateFeature, getMapCoord } from './utils';
@@ -30,12 +40,15 @@ export function useCircleHandlers({
   const setMode = useSetAtom(modeAtom);
   const pmap = useContext(MapContext);
   const setCursor = useSetAtom(cursorStyleAtom);
+  const setDrawCursorLabel = useSetAtom(drawCursorLabelAtom);
   const transact = rep.useTransact();
   const [center, setCenter] = useState<Pos2 | null>(null);
   return {
     click: noop,
     move: (e) => {
       if (selection?.type !== 'single' || !center || !pmap) return;
+
+      const mouse = e.lngLat.toArray() as Pos2;
 
       const wrappedFeature = featureMap.get(selection.id);
 
@@ -44,8 +57,18 @@ export function useCircleHandlers({
 
         const geometry = makeCircle({
           center: center,
-          mouse: e.lngLat.toArray() as Pos2,
+          mouse,
           type: mode.modeOptions?.circleType || CIRCLE_TYPE.MERCATOR
+        });
+
+        setDrawCursorLabel({
+          text: getRadiusDisplayText(
+            center,
+            mouse,
+            mode.modeOptions?.circleType || CIRCLE_TYPE.MERCATOR
+          ),
+          x: e.point.x,
+          y: e.point.y
         });
 
         return transact({
@@ -97,6 +120,7 @@ export function useCircleHandlers({
     },
     up: () => {
       dragTargetRef.current = null;
+      setDrawCursorLabel(null);
       if (selection?.type !== 'single') return;
       const wrappedFeature = featureMap.get(selection.id);
       if (wrappedFeature) {
@@ -119,6 +143,7 @@ export function useCircleHandlers({
       setCursor('');
     },
     enter() {
+      setDrawCursorLabel(null);
       setMode({ mode: Mode.NONE });
     },
     double: noop

--- a/app/lib/handlers/circle.ts
+++ b/app/lib/handlers/circle.ts
@@ -13,6 +13,7 @@ import { USelection } from 'state';
 import {
   cursorStyleAtom,
   drawCursorLabelAtom,
+  ephemeralStateAtom,
   Mode,
   modeAtom,
   selectionAtom
@@ -41,6 +42,7 @@ export function useCircleHandlers({
   const pmap = useContext(MapContext);
   const setCursor = useSetAtom(cursorStyleAtom);
   const setDrawCursorLabel = useSetAtom(drawCursorLabelAtom);
+  const setEphemeralState = useSetAtom(ephemeralStateAtom);
   const transact = rep.useTransact();
   const [center, setCenter] = useState<Pos2 | null>(null);
   return {
@@ -70,6 +72,8 @@ export function useCircleHandlers({
           x: e.point.x,
           y: e.point.y
         });
+
+        setEphemeralState({ type: 'circle-drawing', center, mouse });
 
         return transact({
           putFeatures: [
@@ -121,6 +125,7 @@ export function useCircleHandlers({
     up: () => {
       dragTargetRef.current = null;
       setDrawCursorLabel(null);
+      setEphemeralState({ type: 'none' });
       if (selection?.type !== 'single') return;
       const wrappedFeature = featureMap.get(selection.id);
       if (wrappedFeature) {
@@ -144,6 +149,7 @@ export function useCircleHandlers({
     },
     enter() {
       setDrawCursorLabel(null);
+      setEphemeralState({ type: 'none' });
       setMode({ mode: Mode.NONE });
     },
     double: noop

--- a/app/lib/handlers/none.ts
+++ b/app/lib/handlers/none.ts
@@ -221,6 +221,7 @@ export function useNoneHandlers({
       void endSnapshot();
       setCursor(CURSOR_DEFAULT);
       setDrawCursorLabel(null);
+      setEphemeralState({ type: 'none' });
     },
     move: (e) => {
       if (dragTargetRef.current === null) {
@@ -309,6 +310,11 @@ export function useNoneHandlers({
                   text: getRadiusDisplayText(prop.center, nextCoord, prop.type),
                   x: e.point.x,
                   y: e.point.y
+                });
+                setEphemeralState({
+                  type: 'circle-drawing',
+                  center: prop.center,
+                  mouse: nextCoord
                 });
               }
             }

--- a/app/lib/handlers/none.ts
+++ b/app/lib/handlers/none.ts
@@ -9,6 +9,7 @@ import { decodeId, encodeVertex } from 'app/lib/id';
 import { UIDMap } from 'app/lib/id_mapper';
 import * as utils from 'app/lib/map_component_utils';
 import * as ops from 'app/lib/map_operations';
+import { getCircleProp, getRadiusDisplayText } from 'app/lib/circle';
 import { useEndSnapshot, useStartSnapshot } from 'app/lib/persistence/shared';
 import { captureException } from 'integrations/errors';
 import { useSetAtom } from 'jotai';
@@ -17,6 +18,7 @@ import { useRef } from 'react';
 import { USelection } from 'state';
 import {
   cursorStyleAtom,
+  drawCursorLabelAtom,
   ephemeralStateAtom,
   Mode,
   selectionAtom
@@ -52,6 +54,7 @@ export function useNoneHandlers({
   const setMode = useSetAtom(modeAtom);
   const setSelection = useSetAtom(selectionAtom);
   const setCursor = useSetAtom(cursorStyleAtom);
+  const setDrawCursorLabel = useSetAtom(drawCursorLabelAtom);
   const transact = rep.useTransact();
   const endSnapshot = useEndSnapshot();
   const startSnapshot = useStartSnapshot();
@@ -217,6 +220,7 @@ export function useNoneHandlers({
       dragTargetRef.current = null;
       void endSnapshot();
       setCursor(CURSOR_DEFAULT);
+      setDrawCursorLabel(null);
     },
     move: (e) => {
       if (dragTargetRef.current === null) {
@@ -287,12 +291,27 @@ export function useNoneHandlers({
               ) as Pos2;
             }
 
-            const { feature: newFeature, wasRectangle } = ops.setCoordinates({
+            const {
+              feature: newFeature,
+              wasRectangle,
+              wasCircle
+            } = ops.setCoordinates({
               feature: feature.feature,
               position: nextCoord,
               breakRectangle: e.originalEvent.metaKey,
               vertexId: id
             });
+
+            if (wasCircle) {
+              const prop = getCircleProp(feature.feature);
+              if (prop) {
+                setDrawCursorLabel({
+                  text: getRadiusDisplayText(prop.center, nextCoord, prop.type),
+                  x: e.point.x,
+                  y: e.point.y
+                });
+              }
+            }
 
             if (wasRectangle && !mode?.modeOptions?.hasResizedRectangle) {
               setMode((mode) => {

--- a/app/lib/load_and_augment_style.ts
+++ b/app/lib/load_and_augment_style.ts
@@ -24,9 +24,12 @@ const CIRCLE_LAYOUT: mapboxgl.CircleLayout = {};
 
 export const FEATURES_SOURCE_NAME = 'features';
 export const EPHEMERAL_SOURCE_NAME = 'ephemeral';
+export const CIRCLE_DRAWING_SOURCE_NAME = 'circle-drawing';
 
 const EPHEMERAL_LINE_LAYER_NAME = 'ephemeral-line';
 const EPHEMERAL_FILL_LAYER_NAME = 'ephemeral-fill';
+export const CIRCLE_DRAWING_LINE_LAYER_NAME = 'circle-drawing-line';
+export const CIRCLE_DRAWING_CENTER_LAYER_NAME = 'circle-drawing-center';
 
 const FEATURES_POINT_HALO_LAYER_NAME = 'features-symbol-halo';
 const FEATURES_POINT_LAYER_NAME = 'features-symbol';
@@ -104,6 +107,10 @@ export function addEditingLayers({
 }) {
   style.sources[FEATURES_SOURCE_NAME] = emptyGeoJSONSource;
   style.sources[EPHEMERAL_SOURCE_NAME] = emptyGeoJSONSource;
+  style.sources[CIRCLE_DRAWING_SOURCE_NAME] = {
+    type: 'geojson',
+    data: { type: 'FeatureCollection', features: [] }
+  };
 
   if (!style.layers) {
     throw new Error('Style unexpectedly had no layers');
@@ -239,6 +246,34 @@ export function makeLayers({
         'icon-emissive-strength': 1,
         'text-emissive-strength': 1
       } as mapboxgl.SymbolPaint
+    } as mapboxgl.AnyLayer,
+
+    {
+      id: CIRCLE_DRAWING_LINE_LAYER_NAME,
+      type: 'line',
+      source: CIRCLE_DRAWING_SOURCE_NAME,
+      filter: ['==', '$type', 'LineString'],
+      paint: {
+        'line-color': LINE_COLORS_SELECTED,
+        'line-width': 1.5,
+        'line-dasharray': [4, 3],
+        'line-emissive-strength': 1
+      } as mapboxgl.LinePaint
+    } as mapboxgl.AnyLayer,
+
+    {
+      id: CIRCLE_DRAWING_CENTER_LAYER_NAME,
+      type: 'circle',
+      source: CIRCLE_DRAWING_SOURCE_NAME,
+      filter: ['==', '$type', 'Point'],
+      layout: CIRCLE_LAYOUT,
+      paint: {
+        'circle-color': 'white',
+        'circle-radius': 5,
+        'circle-stroke-color': LINE_COLORS_SELECTED,
+        'circle-stroke-width': 2,
+        'circle-emissive-strength': 1
+      } as mapboxgl.CirclePaint
     } as mapboxgl.AnyLayer,
 
     ...(typeof previewProperty === 'string'

--- a/app/lib/pmap/index.ts
+++ b/app/lib/pmap/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'app/lib/constants';
 import type { IDMap } from 'app/lib/id_mapper';
 import loadAndAugmentStyle, {
+  CIRCLE_DRAWING_SOURCE_NAME,
   EPHEMERAL_SOURCE_NAME,
   FEATURES_SOURCE_NAME
 } from 'app/lib/load_and_augment_style';
@@ -359,6 +360,40 @@ export default class PMap {
     // TODO: fix flash
     mSetData(ephemeralSource, groups.ephemeral, 'ephem');
     mSetData(featuresSource, groups.features, 'features', force);
+
+    const circleDrawingSource = this.map.getSource(
+      CIRCLE_DRAWING_SOURCE_NAME
+    ) as mapboxgl.GeoJSONSource | undefined;
+    if (circleDrawingSource) {
+      if (ephemeralState.type === 'circle-drawing') {
+        circleDrawingSource.setData({
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'LineString',
+                coordinates: [ephemeralState.center, ephemeralState.mouse]
+              }
+            },
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'Point',
+                coordinates: ephemeralState.center
+              }
+            }
+          ]
+        });
+      } else if (this.lastEphemeralState.type === 'circle-drawing') {
+        circleDrawingSource.setData({
+          type: 'FeatureCollection',
+          features: []
+        });
+      }
+    }
 
     this._deckSyntheticData = groups.synthetic;
     this._deckSelectionIds = groups.selectionIds;

--- a/state/jotai.ts
+++ b/state/jotai.ts
@@ -272,6 +272,12 @@ export type EphemeralEditingState =
 
 export const ephemeralStateAtom = atom<EphemeralEditingState>({ type: 'none' });
 
+export const drawCursorLabelAtom = atom<{
+  text: string;
+  x: number;
+  y: number;
+} | null>(null);
+
 export { Mode, MODE_INFO, modeAtom };
 
 export const lastSearchResultAtom = atom<QItemAddable | null>(null);

--- a/state/jotai.ts
+++ b/state/jotai.ts
@@ -264,10 +264,17 @@ export interface EphemeralEditingStateLasso {
   box: [Pos2, Pos2];
 }
 
+export interface EphemeralEditingStateCircleDrawing {
+  type: 'circle-drawing';
+  center: Pos2;
+  mouse: Pos2;
+}
+
 export const cursorStyleAtom = atom<React.CSSProperties['cursor']>('default');
 
 export type EphemeralEditingState =
   | EphemeralEditingStateLasso
+  | EphemeralEditingStateCircleDrawing
   | { type: 'none' };
 
 export const ephemeralStateAtom = atom<EphemeralEditingState>({ type: 'none' });


### PR DESCRIPTION
## Summary

- Shows a small tooltip with the radius measurement when drawing a circle
- Adds a white circle marker at the center and a dashed blue line from center to cursor while drawing a new circle or dragging a vertex to resize an existing one
- Reinforces visually that the tooltip measurement is the radius, not a diameter or circumference
- Uses a dedicated Mapbox GL GeoJSON source (`circle-drawing`) with `line-dasharray` and circle layers, driven by a new `circle-drawing` ephemeral state type
- Also shortens the Mercator radius label from "Mercator m" to "m"

## Test plan

- [ ] Draw a new circle: confirm dashed line, center dot, and tooltip appear while dragging, disappear on mouse up
- [ ] Select an existing circle and drag a vertex handle: confirm same visuals appear and disappear correctly
- [ ] Verify no artifacts remain after completing or cancelling a circle operation
- [ ] Test in both Mercator and Geodesic circle modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)