### PR TITLE
Fix Firefox  Issues

### DIFF
--- a/app/components/map_component.tsx
+++ b/app/components/map_component.tsx
@@ -4,7 +4,10 @@ import { env } from 'app/lib/env_client';
 import type { FlatbushLike } from 'app/lib/generate_flatbush_instance';
 import { EmptyIndex } from 'app/lib/generate_flatbush_instance';
 import { useHandlers } from 'app/lib/handlers/index';
-import { CLICKABLE_LAYERS } from 'app/lib/load_and_augment_style';
+import {
+  CLICKABLE_LAYERS,
+  FEATURES_SOURCE_NAME
+} from 'app/lib/load_and_augment_style';
 import { wrappedFeaturesFromMapFeatures } from 'app/lib/map_component_utils';
 import type { PMapHandlers } from 'app/lib/pmap';
 import PMap from 'app/lib/pmap';
@@ -236,8 +239,7 @@ export const MapComponent = memo(function MapComponent({
 
   const throttledMovePointer = useMemo(() => {
     function fastMovePointer(point: mapboxgl.Point) {
-      if (!map || !map.map.isStyleLoaded()) return;
-
+      if (!map || !map.map.getSource(FEATURES_SOURCE_NAME)) return;
       const features = map.map.queryRenderedFeatures(point, {
         layers: CLICKABLE_LAYERS
       });
@@ -248,9 +250,7 @@ export const MapComponent = memo(function MapComponent({
         });
         setCursor(syntheticUnderCursor || features.length ? 'move' : '');
       } catch (_e) {
-        // Deck can throw here if it's just been initialized
-        // or uninitialized.
-        // console.error(e);
+        // Deck can throw here if it's just been initialized or uninitialized.
       }
     }
     return fastMovePointer;
@@ -381,12 +381,12 @@ export const MapComponent = memo(function MapComponent({
         const mapDivBox = mapDivRef.current?.getBoundingClientRect();
         const map = mapRef.current;
         if (mapDivBox && map) {
-          const featureUnderMouse = map.map.queryRenderedFeatures(
-            [event.pageX - mapDivBox.left, event.pageY - mapDivBox.top],
-            {
-              layers: CLICKABLE_LAYERS
-            }
-          );
+          const featureUnderMouse = map.map.getSource(FEATURES_SOURCE_NAME)
+            ? map.map.queryRenderedFeatures(
+                [event.pageX - mapDivBox.left, event.pageY - mapDivBox.top],
+                { layers: CLICKABLE_LAYERS }
+              )
+            : [];
 
           const position = map.map
             .unproject([

--- a/app/components/map_component.tsx
+++ b/app/components/map_component.tsx
@@ -236,7 +236,8 @@ export const MapComponent = memo(function MapComponent({
 
   const throttledMovePointer = useMemo(() => {
     function fastMovePointer(point: mapboxgl.Point) {
-      if (!map) return;
+      if (!map || map.map.isStyleLoaded()) return;
+
       const features = map.map.queryRenderedFeatures(point, {
         layers: CLICKABLE_LAYERS
       });

--- a/app/components/map_component.tsx
+++ b/app/components/map_component.tsx
@@ -236,7 +236,7 @@ export const MapComponent = memo(function MapComponent({
 
   const throttledMovePointer = useMemo(() => {
     function fastMovePointer(point: mapboxgl.Point) {
-      if (!map || map.map.isStyleLoaded()) return;
+      if (!map || !map.map.isStyleLoaded()) return;
 
       const features = map.map.queryRenderedFeatures(point, {
         layers: CLICKABLE_LAYERS

--- a/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
+++ b/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
@@ -464,8 +464,12 @@ exports[`loadAndAugmentStyle 1`] = `
               1,
             ],
             [
-              "var",
-              "sym",
+              "concat",
+              "maki-",
+              [
+                "var",
+                "sym",
+              ],
             ],
             "",
           ],
@@ -990,8 +994,12 @@ exports[`makeLayers > categorical 2`] = `
             1,
           ],
           [
-            "var",
-            "sym",
+            "concat",
+            "maki-",
+            [
+              "var",
+              "sym",
+            ],
           ],
           "",
         ],
@@ -1506,8 +1514,12 @@ exports[`makeLayers > none 1`] = `
             1,
           ],
           [
-            "var",
-            "sym",
+            "concat",
+            "maki-",
+            [
+              "var",
+              "sym",
+            ],
           ],
           "",
         ],
@@ -1983,8 +1995,12 @@ exports[`makeLayers > ramp 1`] = `
             1,
           ],
           [
-            "var",
-            "sym",
+            "concat",
+            "maki-",
+            [
+              "var",
+              "sym",
+            ],
           ],
           "",
         ],
@@ -2505,8 +2521,12 @@ exports[`makeLayers > with preview property 1`] = `
             1,
           ],
           [
-            "var",
-            "sym",
+            "concat",
+            "maki-",
+            [
+              "var",
+              "sym",
+            ],
           ],
           "",
         ],

--- a/app/lib/load_and_augment_style.ts
+++ b/app/lib/load_and_augment_style.ts
@@ -195,7 +195,12 @@ export function makeLayers({
           'let',
           'sym',
           ['coalesce', ['get', 'marker-symbol'], ''],
-          ['case', ['>', ['length', ['var', 'sym']], 1], ['var', 'sym'], '']
+          [
+            'case',
+            ['>', ['length', ['var', 'sym']], 1],
+            ['concat', 'maki-', ['var', 'sym']],
+            ''
+          ]
         ],
         'icon-size': [
           'match',

--- a/app/lib/maki.ts
+++ b/app/lib/maki.ts
@@ -36,8 +36,9 @@ export async function loadMakiIcons(map: mapboxgl.Map): Promise<void> {
       return new Promise<void>((resolve) => {
         const img = new Image(15, 15);
         img.onload = () => {
-          if (!map.hasImage(name)) {
-            map.addImage(name, img, { sdf: true });
+          const mapId = `maki-${name}`;
+          if (!map.hasImage(mapId)) {
+            map.addImage(mapId, img, { sdf: true });
           }
           resolve();
         };

--- a/app/lib/map_component_utils.ts
+++ b/app/lib/map_component_utils.ts
@@ -106,6 +106,7 @@ export function fuzzyClick(
     layers: CLICKABLE_LAYERS,
     filter: ['!has', 'lasso']
   });
+
   if (!mapFeatures.length) {
     mapFeatures = map.queryRenderedFeatures(bufferPoint(e.point), {
       layers: CLICKABLE_LAYERS,
@@ -133,7 +134,13 @@ export function fuzzyClick(
   }
 
   results.sort((a, b) => {
-    return a.wrappedFeature.at > b.wrappedFeature.at ? -1 : 1;
+    if (a.wrappedFeature.at !== b.wrappedFeature.at) {
+      return a.wrappedFeature.at > b.wrappedFeature.at ? -1 : 1;
+    }
+    // If the wrappedFeature.at is the same, return the Vertex first
+    return a.decodedId.type === 'vertex' && b.decodedId.type === 'feature'
+      ? -1
+      : 1;
   });
 
   return results[0] || null;

--- a/app/lib/pmap/index.ts
+++ b/app/lib/pmap/index.ts
@@ -279,8 +279,7 @@ export default class PMap {
     map.setTerrain(null);
     // set projection to last known value (if any) so that style reloads don't reset it to default
     map.setProjection(this.lastStyleOptions?.mapProjection ?? 'globe');
-    // Load maki icons as SDF so they can be recolored via icon-color. Done here rather than on
-    // idle so the replace happens before tiles are painted, avoiding a visible flash.
+    // Load maki icons as SDF so they can be recolored via icon-color.
     void loadMakiIcons(map);
   };
 
@@ -524,8 +523,6 @@ export default class PMap {
 
     // If only styleOptions changed, and the style has imports, update config properties instead of reloading style.
     // Only treat as a styleOptions-only change if the style is already applied to the map (features source exists).
-    // Without this guard, the optimization fires on initial load when the map still has the empty placeholder style,
-    // causing the in-flight style fetch to be discarded and leaving the map blank (especially in Firefox).
     const onlyStyleOptionsChanged =
       styleConfig === this.lastLayer &&
       symbolization === this.lastSymbolization &&

--- a/app/lib/pmap/index.ts
+++ b/app/lib/pmap/index.ts
@@ -125,6 +125,8 @@ export default class PMap {
   // Incremented on each setStyle call; only the most recent call applies its result.
   private _setStyleSeq = 0;
 
+  private _iconsLoaded = false;
+
   // Stored state for per-frame globe projection correction
   private _deckSyntheticData: Feature[] = [];
   private _deckSelectionIds: Set<RawId> = new Set();
@@ -212,6 +214,7 @@ export default class PMap {
     map.on('touchmove', this.onMapTouchMove);
     map.on('touchend', this.onMapTouchEnd);
     map.on('style.load', this.onMapStyleLoad);
+    map.on('idle', this.onMapIdle);
 
     this.presenceMarkers = new Map();
     this.lastSymbolization = symbolization;
@@ -279,7 +282,17 @@ export default class PMap {
     map.setTerrain(null);
     // set projection to last known value (if any) so that style reloads don't reset it to default
     map.setProjection(this.lastStyleOptions?.mapProjection ?? 'globe');
+    // reset so icons are reloaded for the new style on next idle
+    this._iconsLoaded = false;
+  };
+
+  onMapIdle = (event: mapboxgl.MapEvent) => {
+    if (this._iconsLoaded) return;
+    this._iconsLoaded = true;
+    const map = event.target as mapboxgl.Map;
     // Load maki icons as SDF images so marker-symbol icons can be recolored via icon-color.
+    // Done on idle (rather than style.load) to ensure the style sprite has fully loaded first,
+    // avoiding "image already exists" errors when the sprite contains icons with the same names.
     void loadMakiIcons(map);
   };
 

--- a/app/lib/pmap/index.ts
+++ b/app/lib/pmap/index.ts
@@ -124,7 +124,6 @@ export default class PMap {
   // Sequence counter to prevent stale setStyle calls from overwriting newer ones.
   // Incremented on each setStyle call; only the most recent call applies its result.
   private _setStyleSeq = 0;
-
   private _iconsLoaded = false;
 
   // Stored state for per-frame globe projection correction
@@ -534,13 +533,17 @@ export default class PMap {
       JSON.stringify(this.lastCustomRasterLayers) !==
       JSON.stringify(customRasterLayers);
 
-    // If only styleOptions changed, and the style has imports, update config properties instead of reloading style
+    // If only styleOptions changed, and the style has imports, update config properties instead of reloading style.
+    // Only treat as a styleOptions-only change if the style is already applied to the map (features source exists).
+    // Without this guard, the optimization fires on initial load when the map still has the empty placeholder style,
+    // causing the in-flight style fetch to be discarded and leaving the map blank (especially in Firefox).
     const onlyStyleOptionsChanged =
       styleConfig === this.lastLayer &&
       symbolization === this.lastSymbolization &&
       previewProperty === this.lastPreviewProperty &&
       styleOptions !== this.lastStyleOptions &&
-      !customRasterLayersChanged;
+      !customRasterLayersChanged &&
+      !!this.map.getSource(FEATURES_SOURCE_NAME);
 
     if (
       styleConfig === this.lastLayer &&

--- a/app/lib/pmap/index.ts
+++ b/app/lib/pmap/index.ts
@@ -124,7 +124,6 @@ export default class PMap {
   // Sequence counter to prevent stale setStyle calls from overwriting newer ones.
   // Incremented on each setStyle call; only the most recent call applies its result.
   private _setStyleSeq = 0;
-  private _iconsLoaded = false;
 
   // Stored state for per-frame globe projection correction
   private _deckSyntheticData: Feature[] = [];
@@ -213,7 +212,6 @@ export default class PMap {
     map.on('touchmove', this.onMapTouchMove);
     map.on('touchend', this.onMapTouchEnd);
     map.on('style.load', this.onMapStyleLoad);
-    map.on('idle', this.onMapIdle);
 
     this.presenceMarkers = new Map();
     this.lastSymbolization = symbolization;
@@ -281,17 +279,8 @@ export default class PMap {
     map.setTerrain(null);
     // set projection to last known value (if any) so that style reloads don't reset it to default
     map.setProjection(this.lastStyleOptions?.mapProjection ?? 'globe');
-    // reset so icons are reloaded for the new style on next idle
-    this._iconsLoaded = false;
-  };
-
-  onMapIdle = (event: mapboxgl.MapEvent) => {
-    if (this._iconsLoaded) return;
-    this._iconsLoaded = true;
-    const map = event.target as mapboxgl.Map;
-    // Load maki icons as SDF images so marker-symbol icons can be recolored via icon-color.
-    // Done on idle (rather than style.load) to ensure the style sprite has fully loaded first,
-    // avoiding "image already exists" errors when the sprite contains icons with the same names.
+    // Load maki icons as SDF so they can be recolored via icon-color. Done here rather than on
+    // idle so the replace happens before tiles are painted, avoiding a visible flash.
     void loadMakiIcons(map);
   };
 

--- a/app/lib/style_config_adapters.ts
+++ b/app/lib/style_config_adapters.ts
@@ -196,7 +196,7 @@ function updateMapboxStyle(
   if (typeof updatedImports !== 'undefined') {
     result.imports = updatedImports;
   }
-  // Apply Standard fog to non-import styles (OSM, Outdoors) so they get
+  // Apply Standard fog to non-import styles (OSM, Outdoors, Light, Dark) so they get
   // stars and atmospheric haze when in globe projection.
   if (!style.imports) {
     result.fog = STANDARD_FOG;


### PR DESCRIPTION
## Summary
The changes here address issues that Firefox browser exposed but which were latent in the application.

### Vertex selection on polygons
Sort comparator missing equal case caused non-deterministic ordering in Firefox causing the inability to select Vertices -  vertices now reliably sort before features when `at` values (feature ids) are equal.  Closes #987 

### 🚨Map blank on fresh load (default style) 
The `onlyStyleOptionsChanged` optimization was firing before the style was applied to the map, causing the in-
flight style fetch to be discarded and leaving the canvas blank; guarded by checking `features` source exists first. (To replicate, load app in Firefox, select 'LIGHT' map style and reload)

### `queryRenderedFeatures` on unloaded style 
Backwards `isStyleLoaded()` condition in `fastMovePointer` was querying layers before the style was ready causing the folllowing errors in the console. Check added to ensure layers source exists before calling `queryRenderedFeatures`.
<img width="992" height="81" alt="Screenshot 2026-06-09 at 9 20 20 AM" src="https://github.com/user-attachments/assets/8abba339-5dd5-4ea7-a17c-f0798a6b95ac" />

### Maki icon already exists errors
This exists because maki icons were being added to the sprite sheet to light and dark themes (which already contain maki). Maki icons added to the style (for use as Simple Style Spec rendering) have been added with the `maki-` namespace to remove collision with existing icons and allow for coloring in map rendered simple style.
<img width="595" height="79" alt="Screenshot 2026-06-09 at 9 31 04 AM" src="https://github.com/user-attachments/assets/6d97d1c0-1191-4f44-975a-10b69c468744" />

All four bugs were reproducible in Firefox; the `maki` icons issue and `queryRenderedFeatures` issues also produced silent errors in Chrome.

## Test plan

- [x] Fresh reload with LIGHT style in Firefox — map renders
- [x] Fresh reload with DARK style in Firefox — map renders  
- [x] Click a polygon vertex in Firefox — vertex selected, Delete removes vertex not whole feature
- [x] Toggle styles in Firefox — all styles load correctly
- [x] Hover over features — cursor changes correctly
- [x] Use simple style spec with marker-symbol - icons render after style load

🤖 Generated with [Claude Code](https://claude.com/claude-code)