### PR TITLE
Pass VITE_GA_MEASUREMENT_ID secret to build environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
       id-token: write
     env:
       VITE_PUBLIC_MAPBOX_TOKEN: ${{ secrets.VITE_PUBLIC_MAPBOX_TOKEN }}
+      VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Updates GHA scripts to make the google analytics measurement ID available during build, restoring GA4 analytics.