### PR TITLE
Allow map panning when cursor is over polygon features

### DIFF
--- a/app/lib/handlers/none.ts
+++ b/app/lib/handlers/none.ts
@@ -157,25 +157,9 @@ export function useNoneHandlers({
       });
 
       if (!feature?.object || selection.type !== 'single') {
-        const fuzzyResult = utils.fuzzyClick(e, {
-          idMap,
-          featureMap,
-          pmap
-        });
-
-        if (fuzzyResult) {
-          const { wrappedFeature, id } = fuzzyResult;
-          if (
-            selection.type === 'single' &&
-            selection.id !== wrappedFeature.id
-          ) {
-            void startSnapshot(wrappedFeature);
-            dragTargetRef.current = id;
-            setSelection(USelection.single(wrappedFeature.id));
-          }
-          e.preventDefault();
-        }
-
+        // Feature selection is handled by the click event, which fires
+        // after mousedown+mouseup without significant movement. Don't
+        // preventDefault here so the map can pan when the user drags.
         return;
       }
       e.preventDefault();


### PR DESCRIPTION
## Summary

- `mousedown` over a polygon fill was calling `e.preventDefault()`, which blocks mapbox-gl's drag pan — making the map undraggable whenever polygons covered the viewport
- The selection logic in the `down` handler was redundant: the `click` event already handles feature selection after mousedown+mouseup without significant movement
- The `dragTargetRef` being set in that branch was a no-op — the `move` handler does nothing with feature-type drag IDs (hits `break`)
- Removing this code lets the map pan freely over polygons while keeping click-to-select working via the existing `click` handler

## Test plan

- [x] Load a GeoJSON file with polygons that cover most of the map — confirm the map can be dragged freely
- [x] Click on a polygon (no drag) — confirm it gets selected
- [x] Click on a different polygon while one is selected — confirm selection switches
- [x] Drag a vertex on a selected polygon — confirm vertex dragging still works
- [x] Shift+drag for lasso select — confirm still works
- [x] Alt+drag to move a selected feature — confirm still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)