### PR TITLE
Add Share button with URL-encoded data link

### DIFF
--- a/app/components/dialogs.tsx
+++ b/app/components/dialogs.tsx
@@ -10,6 +10,7 @@ import { RasterLayerDialog } from 'app/components/dialogs/raster_layer';
 import { QuickswitcherDialog } from 'app/components/search/quickswitcher';
 import SimplifyDialog from 'app/components/dialogs/simplify';
 import AboutModal from 'app/components/about_modal';
+import { ShareDialog } from 'app/components/dialogs/share';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { useAtom } from 'jotai';
 import { Dialog as D } from 'radix-ui';
@@ -68,6 +69,7 @@ export const Dialogs = memo(function Dialogs() {
       extraWide = true;
       return <AboutModal open={true} />;
     })
+    .with({ type: 'share' }, () => <ShareDialog onClose={onClose} />)
     .exhaustive();
 
   return (

--- a/app/components/dialogs/share.tsx
+++ b/app/components/dialogs/share.tsx
@@ -1,8 +1,8 @@
-import { Share2Icon, CopyIcon, CheckIcon } from '@radix-ui/react-icons';
+import { Share2Icon, CopyIcon } from '@radix-ui/react-icons';
 import { DialogHeader } from 'app/components/dialog';
 import * as E from 'app/components/elements';
 import { useAtomValue } from 'jotai';
-import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { dataAtom } from 'state/jotai';
 import type { FeatureMap } from 'types';
 import { UWrappedFeature } from 'types';
@@ -20,14 +20,12 @@ export function buildShareUrl(featureMap: FeatureMap): {
 
 export function ShareDialog({ onClose }: { onClose: () => void }) {
   const data = useAtomValue(dataAtom);
-  const [copied, setCopied] = useState(false);
 
   const { url, tooLong } = buildShareUrl(data.featureMap);
 
   async function copyUrl() {
     await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    toast.success('Copied link');
   }
 
   return (
@@ -56,13 +54,9 @@ export function ShareDialog({ onClose }: { onClose: () => void }) {
                   focus:outline-none"
                 onFocus={(e) => e.target.select()}
               />
-              <E.Button
-                variant="quiet"
-                size="sm"
-                onClick={copyUrl}
-                aria-label="Copy URL"
-              >
-                {copied ? <CheckIcon /> : <CopyIcon />}
+              <E.Button size="xs" onClick={copyUrl} aria-label="Copy URL">
+                <CopyIcon className="w-3 h-3" />
+                Copy
               </E.Button>
             </div>
           </>

--- a/app/components/dialogs/share.tsx
+++ b/app/components/dialogs/share.tsx
@@ -1,4 +1,8 @@
-import { Share2Icon, CopyIcon } from '@radix-ui/react-icons';
+import {
+  Share2Icon,
+  CopyIcon,
+  ExclamationTriangleIcon
+} from '@radix-ui/react-icons';
 import { DialogHeader } from 'app/components/dialog';
 import * as E from 'app/components/elements';
 import { useAtomValue } from 'jotai';
@@ -8,7 +12,7 @@ import type { FeatureMap } from 'types';
 import { UWrappedFeature } from 'types';
 
 const WARN_LENGTH = 2000;
-const MAX_LENGTH = 10000;
+const MAX_URL_LENGTH = 8000;
 
 export function buildShareUrl(featureMap: FeatureMap): {
   url: string;
@@ -21,8 +25,8 @@ export function buildShareUrl(featureMap: FeatureMap): {
   const url = `${window.location.origin}/?data=${encodeURIComponent(dataUri)}`;
   return {
     url,
-    tooLong: url.length >= MAX_LENGTH,
-    longWarning: url.length >= WARN_LENGTH && url.length < MAX_LENGTH
+    tooLong: url.length >= MAX_URL_LENGTH,
+    longWarning: url.length >= WARN_LENGTH && url.length < MAX_URL_LENGTH
   };
 }
 
@@ -43,8 +47,8 @@ export function ShareDialog({ onClose }: { onClose: () => void }) {
         {tooLong ? (
           <E.TextWell variant="destructive">
             The current dataset is too large to share via URL. Share links are
-            limited to {MAX_LENGTH.toLocaleString()} characters. Try reducing
-            the number of features or simplifying geometry.
+            limited to {MAX_URL_LENGTH.toLocaleString()} characters. Try
+            reducing the number of features or simplifying geometry.
           </E.TextWell>
         ) : (
           <>
@@ -53,10 +57,11 @@ export function ShareDialog({ onClose }: { onClose: () => void }) {
               is encoded directly in the URL — no account or upload required.
             </E.TextWell>
             {longWarning && (
-              <E.TextWell variant="destructive">
+              <div className="text-sm py-2 px-3 rounded bg-yellow-50 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-100">
+                <ExclamationTriangleIcon className="inline-block w-3 h-3 mr-1" />
                 This URL is over {WARN_LENGTH.toLocaleString()} characters. Very
                 long URLs may not work in all browsers or apps.
-              </E.TextWell>
+              </div>
             )}
             <div className="flex gap-2 items-center">
               <input

--- a/app/components/dialogs/share.tsx
+++ b/app/components/dialogs/share.tsx
@@ -1,0 +1,78 @@
+import { Share2Icon, CopyIcon, CheckIcon } from '@radix-ui/react-icons';
+import { DialogHeader } from 'app/components/dialog';
+import * as E from 'app/components/elements';
+import { useAtomValue } from 'jotai';
+import { useState } from 'react';
+import { dataAtom } from 'state/jotai';
+import type { FeatureMap } from 'types';
+import { UWrappedFeature } from 'types';
+
+export function buildShareUrl(featureMap: FeatureMap): {
+  url: string;
+  tooLong: boolean;
+} {
+  const fc = UWrappedFeature.mapToFeatureCollection(featureMap);
+  const json = JSON.stringify(fc);
+  const dataUri = `data:application/json,${encodeURIComponent(json)}`;
+  const url = `${window.location.origin}/?data=${encodeURIComponent(dataUri)}`;
+  return { url, tooLong: url.length >= 2000 };
+}
+
+export function ShareDialog({ onClose }: { onClose: () => void }) {
+  const data = useAtomValue(dataAtom);
+  const [copied, setCopied] = useState(false);
+
+  const { url, tooLong } = buildShareUrl(data.featureMap);
+
+  async function copyUrl() {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <>
+      <DialogHeader title="Share" titleIcon={Share2Icon} />
+      <div className="space-y-4">
+        {tooLong ? (
+          <E.TextWell variant="destructive">
+            The current dataset is too large to share via URL. Share links are
+            limited to 2000 characters. Try reducing the number of features or
+            simplifying geometry.
+          </E.TextWell>
+        ) : (
+          <>
+            <E.TextWell>
+              Share this link to load the current data in geojson.io. The data
+              is encoded directly in the URL — no account or upload required.
+            </E.TextWell>
+            <div className="flex gap-2 items-center">
+              <input
+                readOnly
+                value={url}
+                className="flex-1 text-xs font-mono bg-gray-100 dark:bg-gray-800
+                  border border-gray-300 dark:border-gray-600
+                  rounded px-2 py-1.5 text-gray-800 dark:text-gray-200
+                  focus:outline-none"
+                onFocus={(e) => e.target.select()}
+              />
+              <E.Button
+                variant="quiet"
+                size="sm"
+                onClick={copyUrl}
+                aria-label="Copy URL"
+              >
+                {copied ? <CheckIcon /> : <CopyIcon />}
+              </E.Button>
+            </div>
+          </>
+        )}
+        <div className="pt-6 pb-1 flex justify-end">
+          <E.Button type="button" onClick={onClose}>
+            Close
+          </E.Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/components/dialogs/share.tsx
+++ b/app/components/dialogs/share.tsx
@@ -7,21 +7,29 @@ import { dataAtom } from 'state/jotai';
 import type { FeatureMap } from 'types';
 import { UWrappedFeature } from 'types';
 
+const WARN_LENGTH = 2000;
+const MAX_LENGTH = 10000;
+
 export function buildShareUrl(featureMap: FeatureMap): {
   url: string;
   tooLong: boolean;
+  longWarning: boolean;
 } {
   const fc = UWrappedFeature.mapToFeatureCollection(featureMap);
   const json = JSON.stringify(fc);
   const dataUri = `data:application/json,${encodeURIComponent(json)}`;
   const url = `${window.location.origin}/?data=${encodeURIComponent(dataUri)}`;
-  return { url, tooLong: url.length >= 2000 };
+  return {
+    url,
+    tooLong: url.length >= MAX_LENGTH,
+    longWarning: url.length >= WARN_LENGTH && url.length < MAX_LENGTH
+  };
 }
 
 export function ShareDialog({ onClose }: { onClose: () => void }) {
   const data = useAtomValue(dataAtom);
 
-  const { url, tooLong } = buildShareUrl(data.featureMap);
+  const { url, tooLong, longWarning } = buildShareUrl(data.featureMap);
 
   async function copyUrl() {
     await navigator.clipboard.writeText(url);
@@ -35,8 +43,8 @@ export function ShareDialog({ onClose }: { onClose: () => void }) {
         {tooLong ? (
           <E.TextWell variant="destructive">
             The current dataset is too large to share via URL. Share links are
-            limited to 2000 characters. Try reducing the number of features or
-            simplifying geometry.
+            limited to {MAX_LENGTH.toLocaleString()} characters. Try reducing
+            the number of features or simplifying geometry.
           </E.TextWell>
         ) : (
           <>
@@ -44,6 +52,12 @@ export function ShareDialog({ onClose }: { onClose: () => void }) {
               Share this link to load the current data in geojson.io. The data
               is encoded directly in the URL — no account or upload required.
             </E.TextWell>
+            {longWarning && (
+              <E.TextWell variant="destructive">
+                This URL is over {WARN_LENGTH.toLocaleString()} characters. Very
+                long URLs may not work in all browsers or apps.
+              </E.TextWell>
+            )}
             <div className="flex gap-2 items-center">
               <input
                 readOnly

--- a/app/components/dialogs/share.tsx
+++ b/app/components/dialogs/share.tsx
@@ -21,8 +21,7 @@ export function buildShareUrl(featureMap: FeatureMap): {
 } {
   const fc = UWrappedFeature.mapToFeatureCollection(featureMap);
   const json = JSON.stringify(fc);
-  const dataUri = `data:application/json,${encodeURIComponent(json)}`;
-  const url = `${window.location.origin}/?data=${encodeURIComponent(dataUri)}`;
+  const url = `${window.location.origin}/?data=${encodeURIComponent(`data:application/json,${json}`)}`;
   return {
     url,
     tooLong: url.length >= MAX_URL_LENGTH,

--- a/app/components/visual.tsx
+++ b/app/components/visual.tsx
@@ -1,8 +1,9 @@
 import { LayersIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import * as E from 'app/components/elements';
+import { buildShareUrl } from 'app/components/dialogs/share';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Popover, Tooltip as T } from 'radix-ui';
-import { memo, Suspense } from 'react';
+import { memo, Suspense, useMemo } from 'react';
 import { dataAtom, dialogAtom } from 'state/jotai';
 import { DialogHelpers } from 'state/dialog_helpers';
 import { StylesPopover } from './styles/popover';
@@ -13,6 +14,11 @@ export const Visual = memo(function Visual() {
   const data = useAtomValue(dataAtom);
   const openFiles = useOpenFiles();
   const hasFeatures = data.featureMap.size > 0;
+
+  const { tooLong: shareTooLong } = useMemo(
+    () => buildShareUrl(data.featureMap),
+    [data.featureMap]
+  );
 
   return (
     <div className="flex items-center">
@@ -35,6 +41,27 @@ export const Visual = memo(function Visual() {
       >
         Export
       </E.Button>
+      <T.Root>
+        <T.Trigger asChild>
+          <E.Button
+            variant="quiet"
+            aria-label="Share"
+            disabled={!hasFeatures || shareTooLong}
+            onClick={() => {
+              setDialogState(DialogHelpers.share());
+            }}
+          >
+            Share
+          </E.Button>
+        </T.Trigger>
+        {shareTooLong && hasFeatures ? (
+          <E.TContent side="bottom">
+            <span className="whitespace-nowrap">
+              Dataset too large to share via URL
+            </span>
+          </E.TContent>
+        ) : null}
+      </T.Root>
 
       <T.Root>
         <Popover.Root>

--- a/app/components/visual.tsx
+++ b/app/components/visual.tsx
@@ -1,4 +1,4 @@
-import { LayersIcon, InfoCircledIcon } from '@radix-ui/react-icons';
+import { LayersIcon, InfoCircledIcon, Share2Icon } from '@radix-ui/react-icons';
 import * as E from 'app/components/elements';
 import { buildShareUrl } from 'app/components/dialogs/share';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -42,18 +42,20 @@ export const Visual = memo(function Visual() {
         Export
       </E.Button>
       <T.Root>
-        <T.Trigger asChild>
-          <E.Button
-            variant="quiet"
-            aria-label="Share"
-            disabled={!hasFeatures || shareTooLong}
-            onClick={() => {
-              setDialogState(DialogHelpers.share());
-            }}
-          >
-            Share
-          </E.Button>
-        </T.Trigger>
+        <div className="h-10 w-10 p-1 flex items-stretch">
+          <T.Trigger asChild>
+            <E.Button
+              variant="quiet"
+              aria-label="Share"
+              disabled={!hasFeatures || shareTooLong}
+              onClick={() => {
+                setDialogState(DialogHelpers.share());
+              }}
+            >
+              <Share2Icon />
+            </E.Button>
+          </T.Trigger>
+        </div>
         {shareTooLong && hasFeatures ? (
           <E.TContent side="bottom">
             <span className="whitespace-nowrap">
@@ -73,6 +75,9 @@ export const Visual = memo(function Visual() {
                 </E.Button>
               </Popover.Trigger>
             </T.Trigger>
+            <E.TContent side="bottom">
+              <span className="whitespace-nowrap">Change Basemap</span>
+            </E.TContent>
           </div>
           <E.PopoverContent2 size="md">
             <Suspense fallback={<E.Loading size="sm" />}>
@@ -80,9 +85,6 @@ export const Visual = memo(function Visual() {
             </Suspense>
           </E.PopoverContent2>
         </Popover.Root>
-        <E.TContent side="bottom">
-          <span className="whitespace-nowrap">Change Basemap</span>
-        </E.TContent>
       </T.Root>
       <T.Root>
         <div className="h-10 w-10 p-1 flex items-stretch">

--- a/public/about.md
+++ b/public/about.md
@@ -53,6 +53,12 @@ In addition to exporting GeoJSON, you can choose other file formats such as KML,
 
 When export GeoJSON, geojson.io always exports a FeatureCollection.
 
+## Sharing data
+
+Use the **Share button** to generate a URL that encodes the current GeoJSON data directly in the link. Anyone with the link can open it in geojson.io and see the same data — no account or file upload required.
+
+Share links use the `?data` URL parameter with a URL-encoded data URI. Because URLs have practical length limits, the Share button is only available when the encoded URL is fewer than 2000 characters. For larger datasets, use the Export button to save a file and share that instead.
+
 ## Supported File Types
 
 **geojson.io** supports the following file types for import and export as outlined in the table below.

--- a/public/about.md
+++ b/public/about.md
@@ -57,7 +57,7 @@ When export GeoJSON, geojson.io always exports a FeatureCollection.
 
 Use the **Share button** to generate a URL that encodes the current GeoJSON data directly in the link. Anyone with the link can open it in geojson.io and see the same data — no account or file upload required.
 
-Share links use the `?data` URL parameter with a URL-encoded data URI. Because URLs have practical length limits, the Share button is only available when the encoded URL is fewer than 2000 characters. For larger datasets, use the Export button to save a file and share that instead.
+Share links use the `?data` URL parameter with a URL-encoded data URI. Because URLs have practical length limits, the Share button is only available when the encoded URL is fewer than 8,000 characters. For larger datasets, use the Export button to save a file and share that instead.
 
 ## Supported File Types
 

--- a/state/dialog_helpers.ts
+++ b/state/dialog_helpers.ts
@@ -29,6 +29,10 @@ export const DIALOG_CONFIGS = {
     title: 'About',
     description: 'About this application'
   },
+  share: {
+    title: 'Share',
+    description: 'Share a link to the current data'
+  },
   from_url: {
     title: 'Import from URL',
     description: 'Load GeoJSON data from a URL'
@@ -66,6 +70,11 @@ export const DialogHelpers = {
   about: () => ({
     type: 'about' as const,
     ...DIALOG_CONFIGS.about
+  }),
+
+  share: () => ({
+    type: 'share' as const,
+    ...DIALOG_CONFIGS.share
   }),
 
   fromUrl: () => ({

--- a/state/dialog_state.ts
+++ b/state/dialog_state.ts
@@ -94,6 +94,11 @@ type DialogState =
       title: string;
       description: string;
     }
+  | {
+      type: 'share';
+      title: string;
+      description: string;
+    }
   | null;
 
 export const dialogAtom = atomWithReset<DialogState>(null);


### PR DESCRIPTION
## Summary

- Adds a **Share** menu item after Export in the toolbar
- Opens a modal with a shareable URL that encodes the current GeoJSON as a `?data=data:application/json,...` query parameter — no upload or account needed
- Share button is disabled (grayed out) when the resulting URL would be ≥ 8000 characters, with a tooltip explaining why
- A warning is shown if the URL is greater than 2000 characters
- Adds a **Sharing data** section to the About panel documenting the feature and its URL length limit
- Confirmed through testing that geojson.io will return `Error: URI Too Long` and not load the app if the URL is 8220 characters or longer.

## Test plan

- [ ] Draw one or a few small features → Share button becomes enabled
- [ ] Click Share → modal opens with a URL in a read-only input
- [ ] Click copy icon → URL is copied to clipboard, toast shows
- [ ] Open the copied URL in a new tab → same features load on the map
- [ ] Add many features with complex geometry until the encoded URL exceeds 2000 chars → Share button becomes grayed out with tooltip "Dataset too large to share via URL"
- [ ] No features on map → Share button is disabled (same as Export)
- [ ] Check About panel → "Sharing data" section is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)