### PR TITLE
Add WMS layer support to Add Raster Layer

### DIFF
--- a/app/components/dialogs/raster_layer.tsx
+++ b/app/components/dialogs/raster_layer.tsx
@@ -25,8 +25,16 @@ function validateTileUrl(url: string): string | undefined {
     return 'URL must start with https://';
   }
   if (isWmsUrl(url)) {
-    if (!url.includes('{bbox-epsg-3857}')) {
-      return 'WMS URL must include {bbox-epsg-3857} placeholder';
+    const missing: string[] = [];
+    if (!/service=wms/i.test(url)) missing.push('SERVICE=WMS');
+    if (!/request=getmap/i.test(url)) missing.push('REQUEST=GetMap');
+    if (!/crs=epsg:3857/i.test(url)) missing.push('CRS=EPSG:3857');
+    if (!/width=\d+/i.test(url)) missing.push('WIDTH');
+    if (!/height=\d+/i.test(url)) missing.push('HEIGHT');
+    if (!url.includes('{bbox-epsg-3857}'))
+      missing.push('BBOX={bbox-epsg-3857}');
+    if (missing.length > 0) {
+      return `WMS URL is missing required parameters: ${missing.join(', ')}`;
     }
     return;
   }

--- a/app/components/dialogs/raster_layer.tsx
+++ b/app/components/dialogs/raster_layer.tsx
@@ -15,10 +15,20 @@ interface RasterLayerFormValues {
   tileUrl: string;
 }
 
+function isWmsUrl(url: string): boolean {
+  return /service=wms/i.test(url) || url.includes('{bbox-epsg-3857}');
+}
+
 function validateTileUrl(url: string): string | undefined {
   const isLocal = url.includes('localhost') || url.includes('127.0.0.1');
   if (!url.startsWith('https://') && !(isLocal && url.startsWith('http://'))) {
     return 'URL must start with https://';
+  }
+  if (isWmsUrl(url)) {
+    if (!url.includes('{bbox-epsg-3857}')) {
+      return 'WMS URL must include {bbox-epsg-3857} placeholder';
+    }
+    return;
   }
   // Accept {y} (XYZ scheme) or {-y} (TMS scheme, flipped Y axis)
   if (
@@ -26,7 +36,7 @@ function validateTileUrl(url: string): string | undefined {
     !url.includes('{x}') ||
     (!url.includes('{y}') && !url.includes('{-y}'))
   ) {
-    return 'Must include {z}, {x}, and {y} (or {-y} for TMS) placeholders';
+    return 'Must include {z}, {x}, and {y} (or {-y} for TMS) placeholders, or use a WMS URL with {bbox-epsg-3857}';
   }
 }
 
@@ -123,11 +133,17 @@ export function RasterLayerDialog({
               placeholder="https://example.com/tiles/{z}/{x}/{y}.png"
             />
             <TextWell>
-              Provide a tile URL template starting with https:// (or http:// for
-              localhost) and including {'{z}'}, {'{x}'}, and {'{y}'}{' '}
-              placeholders for zoom level and tile coordinates. Use {'{-y}'}{' '}
-              instead of {'{y}'} for TMS layers with a flipped Y axis (e.g. from
-              JOSM or QGIS).
+              <strong>XYZ/TMS:</strong> Provide a tile URL template including{' '}
+              {'{z}'}, {'{x}'}, and {'{y}'} placeholders. Use {'{-y}'} instead
+              of {'{y}'} for TMS layers with a flipped Y axis (e.g. from JOSM or
+              QGIS).
+              <br />
+              <br />
+              <strong>WMS:</strong> Provide a WMS GetMap URL with{' '}
+              {'{bbox-epsg-3857}'} as the BBOX parameter value. The URL must
+              include <code>SERVICE=WMS</code>, <code>REQUEST=GetMap</code>,{' '}
+              <code>CRS=EPSG:3857</code>, <code>WIDTH=256</code>, and{' '}
+              <code>HEIGHT=256</code>.
             </TextWell>
             <TextWell>
               <strong>Note:</strong> Your raster layer configuration will be

--- a/app/components/dialogs/raster_layer.tsx
+++ b/app/components/dialogs/raster_layer.tsx
@@ -140,10 +140,10 @@ export function RasterLayerDialog({
               <br />
               <br />
               <strong>WMS:</strong> Provide a WMS GetMap URL with{' '}
-              {'{bbox-epsg-3857}'} as the BBOX parameter value. The URL must
-              include <code>SERVICE=WMS</code>, <code>REQUEST=GetMap</code>,{' '}
-              <code>CRS=EPSG:3857</code>, <code>WIDTH=256</code>, and{' '}
-              <code>HEIGHT=256</code>.
+              <code>{'{bbox-epsg-3857}'}</code> as the BBOX parameter value. The
+              URL must include <code>SERVICE=WMS</code>,{' '}
+              <code>REQUEST=GetMap</code>, <code>CRS=EPSG:3857</code>,{' '}
+              <code>WIDTH=256</code>, and <code>HEIGHT=256</code>.
             </TextWell>
             <TextWell>
               <strong>Note:</strong> Your raster layer configuration will be

--- a/app/lib/style_config_adapters.ts
+++ b/app/lib/style_config_adapters.ts
@@ -79,7 +79,10 @@ function updateMapboxStyle(
     (layer) => layer.visible !== false
   );
   visibleCustomRasterLayers.forEach((layer) => {
-    const isTms = layer.tileUrl.includes('{-y}');
+    const isWms =
+      /service=wms/i.test(layer.tileUrl) ||
+      layer.tileUrl.includes('{bbox-epsg-3857}');
+    const isTms = !isWms && layer.tileUrl.includes('{-y}');
     const tiles = [
       isTms ? layer.tileUrl.replace('{-y}', '{y}') : layer.tileUrl
     ];


### PR DESCRIPTION
## Summary

- Adds WMS GetMap URL support alongside existing XYZ/TMS tile URL support in the Add Raster Layer dialog
- Detects WMS URLs by checking for `SERVICE=WMS` (case-insensitive) or the `{bbox-epsg-3857}` placeholder
- WMS URLs are validated to require `{bbox-epsg-3857}` as the bbox parameter value
- WMS URLs pass through to Mapbox GL raster sources unchanged (bypassing TMS `{-y}` handling), since Mapbox GL natively handles `{bbox-epsg-3857}` in tile URLs
- Updated help text in the dialog explains both XYZ/TMS and WMS URL formats

Test with `https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}`

`https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}`

## Test plan

- [x] Add an XYZ tile layer — should still work as before
- [ ] Add a TMS tile layer with `{-y}` — should still work as before
- [x] Add a WMS layer using this URL and verify it renders on the map:
  ```
  https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}
  ```
- [x] Submit a WMS URL missing `{bbox-epsg-3857}` — should show validation error
- [ ] Submit a non-WMS URL missing `{z}/{x}/{y}` — should show the updated error message mentioning WMS as an alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)