### PR TITLE
Fix draw tool menu layering over mode hints

### DIFF
--- a/app/components/elements.tsx
+++ b/app/components/elements.tsx
@@ -338,11 +338,13 @@ export const contentLike = `py-1
     rounded-sm
     shadow-[0_2px_10px_2px_rgba(0,0,0,0.1)]
     ring-1 ring-gray-200 dark:ring-gray-700
-    content-layout z-50`;
+    content-layout`;
 
-export const DDContent = classed(DD.Content)(contentLike);
-export const CMContent = classed(CM.Content)(contentLike);
-export const CMSubContent = classed(CM.SubContent)(contentLike);
+const floatingContentLike = `${contentLike} z-50`;
+
+export const DDContent = classed(DD.Content)(floatingContentLike);
+export const CMContent = classed(CM.Content)(floatingContentLike);
+export const CMSubContent = classed(CM.SubContent)(floatingContentLike);
 
 const styledLabel =
   'block py-1 pl-3 pr-4 text-xs text-gray-500 dark:text-gray-300';
@@ -515,9 +517,9 @@ export const styledButton = ({
       dark:aria-expanded:bg-mb-blue-300
     data-state-on:bg-purple-400 dark:data-state-on:bg-gray-900`
       : variant === 'primary'
-      ? `aria-expanded:bg-mb-blue-300
+        ? `aria-expanded:bg-mb-blue-300
     data-state-on:bg-mb-blue-300`
-      : `
+        : `
     aria-expanded:bg-gray-200 dark:aria-expanded:bg-black
     data-state-on:bg-gray-200 dark:data-state-on:bg-gray-600`,
     'disabled:opacity-50 disabled:cursor-not-allowed',

--- a/app/components/mode_hints.tsx
+++ b/app/components/mode_hints.tsx
@@ -23,8 +23,9 @@ function ModeHint({
   return (
     <div
       className={clsx(
-        'z-0 absolute top-2 left-2 px-2 text-sm flex gap-x-2 items-center dark:text-white',
-        contentLike
+        'absolute top-2 left-2 px-2 text-sm flex gap-x-2 items-center dark:text-white',
+        contentLike,
+        'z-10'
       )}
     >
       <InfoCircledIcon />


### PR DESCRIPTION
## Summary
- Keep dropdown and context menu panels on the floating content z-index layer.
- Move map mode hints to a lower layer so draw tool menus render above them.

Closes #1000

## Validation
- `npx prettier --check "app/components/elements.tsx" "app/components/mode_hints.tsx"`
- `npx eslint "app/components/elements.tsx" "app/components/mode_hints.tsx"`
- `git diff --check`
- `npm run build`
- `npm test`
- Browser check: Rectangle mode + Circle type dropdown; dropdown computed `z-index: 50`, mode hint computed `z-index: 10`, and the overlap point resolves to the `Mercator` menu item.