### PR TITLE
Fix GA4 firing page_view on every map interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,14 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '%VITE_GA_MEASUREMENT_ID%');
+      // Disable automatic page_view tracking to prevent the ?map= camera
+      // parameter (updated via replaceState on every map move) from firing
+      // a page_view on each interaction.
+      gtag('config', '%VITE_GA_MEASUREMENT_ID%', { send_page_view: false });
+      // Fire a single page_view with a clean URL (no query params).
+      gtag('event', 'page_view', {
+        page_location: window.location.origin + window.location.pathname + window.location.hash
+      });
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- GA4's Enhanced Measurement tracks `history.replaceState` calls as `page_view` events
- The map camera position is written to the `?map=` query param via `replaceState` on every pan/zoom, flooding GA4 with page views
- Fixes by setting `send_page_view: false` on the gtag config and manually firing a single `page_view` on load with a clean URL (no query params)

## Test plan

- [ ] Open the app and confirm a single `page_view` event fires on load (check GA4 DebugView or network requests to `google-analytics.com`)
- [ ] Pan/zoom the map and confirm no additional `page_view` events are fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)