### PR TITLE
Fix two-finger pan while drawing & Added panel resizing surface on mobile devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Recent changes to the geojson.io application. Entries are grouped by ship date.
 
 ## 2026-06-25
 
+- **Fix 2 finger pan while in drawing mode:** Fix for users on touch devices, now 2 finger gestures while drawing is in process will make it to the map and will allow for panning.
+- **Mobile Panel Resizing:** On Mobile devices the bottom panel now presents clickable surface for resizing.
 - **Streamlined file import:** Files with unambiguous formats (GeoJSON, KML, GPX, shapefiles, etc.) now import directly without showing a dialog. The import modal only appears when user input is needed (CSV, XLS, coordinate strings). Drag-and-drop and the Import button now share identical logic, and `fitBounds` works correctly after drag-and-drop imports.
 
 ## 2026-06-24

--- a/app/components/legend.tsx
+++ b/app/components/legend.tsx
@@ -48,19 +48,6 @@ function LegendTitle({ title }: { title: string }) {
   );
 }
 
-function LegendContainer({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      className="space-y-1 text-xs
-      bg-white dark:bg-gray-900
-      dark:text-white
-      border border-gray-300 dark:border-black w-48 rounded-t"
-    >
-      {children}
-    </div>
-  );
-}
-
 function LegendRamp({ symbolization }: { symbolization: ISymbolizationRamp }) {
   return (
     <>
@@ -176,14 +163,14 @@ function getRoundNum(num: number) {
     d >= 10
       ? 10
       : d >= 5
-      ? 5
-      : d >= 3
-      ? 3
-      : d >= 2
-      ? 2
-      : d >= 1
-      ? 1
-      : getDecimalRoundNum(d);
+        ? 5
+        : d >= 3
+          ? 3
+          : d >= 2
+            ? 2
+            : d >= 1
+              ? 1
+              : getDecimalRoundNum(d);
 
   return pow10 * d;
 }
@@ -321,9 +308,9 @@ export function Legend() {
     .exhaustive();
 
   return (
-    <div className="space-y-1 absolute bottom-0 right-10 w-48">
+    <div className="space-y-1 absolute bottom-1 right-10 w-48">
       <ScaleControl />
-      <LegendContainer>{legend}</LegendContainer>
+      {legend}
     </div>
   );
 }

--- a/app/components/resizer.tsx
+++ b/app/components/resizer.tsx
@@ -262,7 +262,7 @@ export const BottomResizer = memo(function BottomResizerInner() {
         flex items-center
         justify-center
         h-1
-        hover-none:w-3
+        hover-none:h-3
         z-max
         bg-opacity-0
         dark:bg-opacity-0
@@ -279,8 +279,8 @@ export const BottomResizer = memo(function BottomResizerInner() {
       <div
         className="
         hover-hover:hidden
-        h-16
-        w-1
+        w-16
+        h-1
         rounded
         bg-white"
       />

--- a/app/lib/handlers/line.ts
+++ b/app/lib/handlers/line.ts
@@ -31,6 +31,7 @@ export function useLineHandlers({
   const transact = rep.useTransact();
   const popMoment = usePopMoment();
   const usingTouchEvents = useRef<boolean>(false);
+  const isMultiTouch = useRef<boolean>(false);
   const shiftHeld = useShiftHeld();
   const altHeld = useAltHeld();
 
@@ -146,14 +147,24 @@ export function useLineHandlers({
 
     touchstart: (e) => {
       usingTouchEvents.current = true;
+      if (e.originalEvent.touches.length > 1) {
+        isMultiTouch.current = true;
+        return;
+      }
+      isMultiTouch.current = false;
       e.preventDefault();
     },
 
     touchmove: (e) => {
+      if (e.originalEvent.touches.length > 1 || isMultiTouch.current) return;
       handlers.move(e);
     },
 
     touchend: (e) => {
+      if (isMultiTouch.current) {
+        if (e.originalEvent.touches.length === 0) isMultiTouch.current = false;
+        return;
+      }
       handlers.click(e);
     },
 

--- a/app/lib/handlers/polygon.ts
+++ b/app/lib/handlers/polygon.ts
@@ -37,6 +37,7 @@ export function usePolygonHandlers({
    * Workarounds for Apple Pencil (same as in line drawing)
    */
   const usingTouchEvents = useRef<boolean>(false);
+  const isMultiTouch = useRef<boolean>(false);
 
   const shiftHeld = useShiftHeld();
   const altHeld = useAltHeld();
@@ -201,19 +202,27 @@ export function usePolygonHandlers({
 
     touchstart: (e) => {
       usingTouchEvents.current = true;
+      if (e.originalEvent.touches.length > 1) {
+        isMultiTouch.current = true;
+        return;
+      }
+      isMultiTouch.current = false;
       e.preventDefault();
     },
 
     touchmove: (e) => {
+      if (e.originalEvent.touches.length > 1 || isMultiTouch.current) return;
       e.preventDefault();
-      // If this is a Pencil, allow moving. If it
-      // is a finger, do not.
       if (e.originalEvent?.touches[0]?.force) {
         handlers.move(e);
       }
     },
 
     touchend: (e) => {
+      if (isMultiTouch.current) {
+        if (e.originalEvent.touches.length === 0) isMultiTouch.current = false;
+        return;
+      }
       handlers.click(e);
     },
     up() {


### PR DESCRIPTION
## Fix Two-finger pan while drawing (Reported in #974)

- On touch devices (iPad, iPhone), two-finger pan/zoom gestures during line or polygon drawing were being swallowed by the drawing handlers, preventing Mapbox GL from navigating the map
- Root cause: `touchstart` unconditionally called `e.preventDefault()` and `touchend` unconditionally called `handlers.click()`, regardless of how many fingers were involved
- Fix adds an `isMultiTouch` ref in both `useLineHandlers` and `usePolygonHandlers` — when two or more fingers are detected, touch events are passed through to Mapbox GL rather than treated as drawing actions

### How it works

- `touchstart`: if `touches.length > 1`, set `isMultiTouch = true` and return without calling `preventDefault()` — the map handles the gesture natively
- `touchmove`: bail out if multi-touch, so no phantom point updates during a pan
- `touchend`: skip `click` if `isMultiTouch` is set; reset the flag only once all fingers have lifted (handles the case where two fingers lift one at a time)

Closes #974 

## Fix Mobile Panel Resizability
- On a mobile device the horizontal panel at app bottom did not make a draggable surface visbille or available to click.  Forcing the mobile user to not be able to resize the panel, and providing much reduced map surface. 
- This adds CSS styles to ensure that the handle to resizing the panel is visible and can be used on Mobile devices.
<img width="322" height="690" alt="Screenshot 2026-06-25 at 2 57 03 PM" src="https://github.com/user-attachments/assets/27eee05b-ef0f-4a02-9d90-d80cf68a2daf" />

Closes #986

## Remove LegendContainer & Small Design artifact.
- There is a very small DOM element visible below the Legend, which was seen and after review this can be removed.  I believe our refactor of the Placemark.io legend made this container un-neccesary.
<img width="1111" height="708" alt="Screenshot 2026-06-25 at 11 40 12 AM" src="https://github.com/user-attachments/assets/227ee17f-51a3-4a2b-9d7a-9d228dd4de65" />

## Test plan

- [x] On a touch device, enter line drawing mode, place a point, then use two fingers to pan/zoom — map should navigate without adding new points
- [x] Confirm single-finger tap still adds points correctly
- [x] Repeat for polygon drawing mode
- [x] Confirm Apple Pencil drawing still works (existing `force` check in polygon handler is preserved)
- [ ] Confirm a that a draggable handle is visible and can be used on small devices to change the size of the bottom panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)