### PR TITLE
Fix GA4 page_view firing on every map interaction

### DIFF
--- a/app/components/map_component.tsx
+++ b/app/components/map_component.tsx
@@ -349,7 +349,10 @@ export const MapComponent = memo(function MapComponent({
       const newSearch = otherParams
         ? `?${otherParams}&map=${cameraStr}`
         : `?map=${cameraStr}`;
-      window.history.replaceState(
+      // Use the prototype method directly to bypass GA4's instance-level
+      // patch of history.replaceState, which fires a page_view on every call.
+      History.prototype.replaceState.call(
+        history,
         null,
         '',
         window.location.pathname + newSearch + window.location.hash


### PR DESCRIPTION
## Summary

- `send_page_view: false` in the gtag config only suppresses the initial page_view on load — it does not affect GA4's enhanced measurement feature
- GA4 enhanced measurement patches `history.replaceState` at the instance level and independently fires a `page_view` event on every call
- The `?map=` camera param is updated via `replaceState` on every map move (`onMoveEnd`), causing a flood of page_view events
- Fix: call `History.prototype.replaceState` directly, which bypasses GA4's instance-level patch

## Test plan

- [ ] Move the map and confirm no `page_view` events fire in GA4 DebugView or the Network tab (no hits to `google-analytics.com/g/collect` with `en=page_view`)
- [ ] Confirm the `?map=` query param still updates correctly in the URL on map move
- [ ] Confirm a single `page_view` still fires on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)