### PR TITLE
Fixes Numpad delete key not deleting features & Adds staging Deployment script for Mapboxers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Then, start the development server:
 npm run dev
 ```
 
+## Deploying to Staging
+
+For Mapboxer's who are want to test branches before deploying to production use the `mbx env` CLI tool for authentication and then run `npm run deploy:staging` to deploy to Mapbox's labs.tilestream.net staging server.
+
 This will start the application on `http://localhost:5173`. Open this URL in your web browser to view and interact with the application.
 
 ## History & Attribution

--- a/app/hooks/use_map_keybindings.ts
+++ b/app/hooks/use_map_keybindings.ts
@@ -127,12 +127,13 @@ export function useMapKeybindings() {
   );
 
   useHotkeys(
-    'Backspace, delete',
+    'Backspace, delete, decimal', // decimal is added for numpad [Del.] key strokes
     (e) => {
+      if (e.code === 'NumpadDecimal' && e.key !== 'Delete') return; // gates to only when numLock sets decimal to delete
       e.preventDefault();
       void onDelete();
     },
-    { ...keybindingOptions, useKey: true },
+    keybindingOptions,
     [onDelete]
   );
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "deploy:staging": "vite build --mode staging && aws s3 sync dist/ s3://labs.mapbox.com-staging/geojson-io-staging/ --cache-control max-age=120",
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "npm run lint && vitest run",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,7 @@ function App() {
       <StrictMode>
         <QueryClientProvider client={queryClient}>
           <T.Provider>
-            <Router base="">
+            <Router base={import.meta.env.BASE_URL}>
               <Switch>
                 <Route path="/">
                   <Provider store={store}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig((env) => ({
     env.mode === 'test'
       ? [react(), tsconfigPaths()]
       : [react(), tsconfigPaths(), nodePolyfills()],
-  base: '/',
+  base: env.mode === 'staging' ? '/geojson-io-staging/' : '/',
   build: {
     outDir: './dist'
   },


### PR DESCRIPTION
## Summary 
Reported in #1012  - Using the numpad's `Delete` key with num lock off (sets the keys primary action to Delete) did not delete features in the application.  Secondly, I've added a new `npm` `deploy:staging` script which deploys a staging branch on Mapbox staging servers for branch testing & review (for core maintainers at Mapbox).

## Numpad Delete Issue
This problem stems from how React Hotkeys actually matches keys. react-hotkeys matches primarily on e`vent.code`, not `event.key` — regardless of `useKey`. Its internal normalizer lowercases the code and strips the literal substring "numpad":

- Numpad Del (NumLock off): {key: 'Delete', code: 'NumpadDecimal'} → normalizes to 'decimal'
- Regular Delete: {key: 'Delete', code: 'Delete'} → normalizes to 'delete'

Since the hotkey list was `Backspace, delete`, `decimal` never matched — it has nothing to do with useKey/event.key at all, which is why the earlier fix was unsuccessful.

The fix 

1. Add `decimal` as a third token in the hotkey string, so NumpadDecimal matches via the code path.
2. Guard the callback so it only fires as delete when NumLock is actually producing Delete semantics:
`if (e.code === 'NumpadDecimal' && e.key !== 'Delete') return;`
2. This avoids accidentally deleting when NumLock is on and the numpad . key is pressed elsewhere (where `event.key` would be `.`, not `Delete`).
3. Dropped useKey: true entirely since it wasn't doing anything useful here.

Closes #1012 

## Staging Deployments
Is trying to have team mates test this branch for the fix, it became apparent we needed a staging deployment option for Geojson.io.  This PR add a new `deploy:staging` script to be run after the Mapbox `mbx env` MBX CLI call, which puts this into the labs.mapbox staging bucket for previewing.  

A small change to add some logic to Vite config's `baseUrl` property was required to allow the App router to resolve files at the staging URL (not the root domain level).

## Testing
This branch - has been testing on staging by @emilygamedeveloper for the specific numpad delete fix.  Additional user testing to ensure delete operations continue to work as expected can be implemented on the local branch or on [labs.tilestream.net](https://labs.tilestream.net/geojson-io-staging/)


