### PR TITLE
Tiny README.md change in cloning command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you encounter any issues or have suggestions for new features, please open an
 To run this project locally, you'll need [Node.js](https://nodejs.org/) installed. Then, clone the repository and install dependencies:
 
 ```bash
-git clone https://github.com/mapbox/geojson-io.git
+git clone https://github.com/mapbox/geojson.io.git
 cd geojson.io
 npm install
 ```


### PR DESCRIPTION
I'm sorry if this PR would be considered spam, but the typo leads to a failed cloning of the repo and it's not immediately obvious why when you copy it directly from the README.